### PR TITLE
deploy: set the default storage class to DigitalOcean

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ kubectl create -f csi-nodeplugin-rbac.yaml
 kubectl create -f csi-nodeplugin-do.yaml
 ```
 
+A new storage class will be created with the name `do-block-storage` which is
+responsible for dynamic provisioning. This is set to "default" for dynamic
+provisioning. If you're using multiple storage classes you might want to remove
+the annotation from the `csi-storageclass.yaml` and re-deploy it.
+
 This is based on the recommended mechanism of deploying CSI drivers on Kubernetes: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md#recommended-mechanism-for-deploying-csi-drivers-on-kubernetes
 
 Note that the proposal is still work in progress and not all of the written

--- a/deploy/kubernetes/csi-storageclass.yaml
+++ b/deploy/kubernetes/csi-storageclass.yaml
@@ -2,4 +2,6 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: do-block-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: com.digitalocean.csi.dobs


### PR DESCRIPTION
This aligns with our plugin and also makes it easier to deploy
PersistentVolumeClaims because users don't have to specify a
`storageClassName` anymore.

closes #11