### PR TITLE
Change secret name to digitalocean

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,23 @@ Cloud Foundry. Feel free to test it on other CO's and give us a feedback.
 
 #### 1. Create a secret with your DigitalOcean API Access Token:
 
-First encode your token in base64 (in this example, the string starting with
-`a05...` is the API token):
-
-```
-$  echo -n "a05dd2f26b9b9ac2asdasdsd3fabf713560a129323890123cb5d1ec17513e06da" | base64
-YTA1ZGQyZjI2YjliOWFjMmFzZGFzZHNkM2ZhYmY3MTM1NjBhMTI5MzIzODkwMTIzY2I1ZDFlYzE3NTEzZTA2ZGE=
-```
-
-Write a secret resource file with the base64 output above:
+Replace the placeholder string starting with `a05...` with your own secret and
+save it as `secret.yml`: 
 
 ```
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dotoken
-type: Opaque
-data:
-  token: YTA1ZGQyZjI2YjliOWFjMmFzZGFzZHNkM2ZhYmY3MTM1NjBhMTI5MzIzODkwMTIzY2I1ZDFlYzE3NTEzZTA2ZGE=
+  name: digitalocean
+stringData:
+  access-token: "a05dd2f26b9b9ac2asdas__REPLACE_ME____123cb5d1ec17513e06da"
 ```
 
 and create the secret using kubectl:
 
 ```
 $ kubectl create -f ./secret.yml
-secret "dotoken" created
+secret "digitalocean" created
 ```
 
 #### 2. Deploy the CSI plugin and sidecars:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: digitalocean
+  namespace: kube-system
 stringData:
   access-token: "a05dd2f26b9b9ac2asdas__REPLACE_ME____123cb5d1ec17513e06da"
 ```
@@ -32,6 +33,15 @@ and create the secret using kubectl:
 ```
 $ kubectl create -f ./secret.yml
 secret "digitalocean" created
+```
+
+You should now see the digitalocean secret in the `kube-system` namespace along with other secrets
+
+```
+$ kubectl -n kube-system get secrets
+NAME                  TYPE                                  DATA      AGE
+default-token-jskxx   kubernetes.io/service-account-token   3         18h
+digitalocean          Opaque                                1         18h
 ```
 
 #### 2. Deploy the CSI plugin and sidecars:

--- a/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
@@ -1,0 +1,354 @@
+# Copyright 2018 DigitalOcean
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+# Configuration to deploy release version of the CSI DigitalOcean
+# plugin (https://github.com/digitalocean/csi-digitalocean) compatible with
+# Kubernetes >=v1.10
+#
+# example usage: kubectl create -f <this_file>
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: do-block-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: com.digitalocean.csi.dobs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-attacher
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-attacher-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-attacher-doplugin
+  labels:
+    app: csi-attacher-doplugin
+spec:
+  selector:
+    app: csi-attacher-doplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-attacher-doplugin
+spec:
+  serviceName: "csi-attacher-doplugin"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-attacher-doplugin
+    spec:
+      serviceAccount: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: digitalocean-csi-plugin
+          image: digitalocean/do-csi-plugin:v0.0.1
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: DIGITALOCEAN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: digitalocean
+                  key: access-token
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+    
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-provisioner-doplugin
+  labels:
+    app: csi-provisioner-doplugin
+spec:
+  selector:
+    app: csi-provisioner-doplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-provisioner-doplugin
+spec:
+  serviceName: "csi-provisioner-doplugin"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-doplugin
+    spec:
+      serviceAccount: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          args:
+            - "--provisioner=com.digitalocean.csi.dobs"
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: digitalocean-csi-plugin
+          image: digitalocean/do-csi-plugin:v0.0.1
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: DIGITALOCEAN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: digitalocean
+                  key: access-token
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-doplugin
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-doplugin
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-doplugin
+subjects:
+  - kind: ServiceAccount
+    name: csi-doplugin
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: csi-doplugin
+  apiGroup: rbac.authorization.k8s.io          
+
+---
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: csi-doplugin
+spec:
+  selector:
+    matchLabels:
+      app: csi-doplugin
+  template:
+    metadata:
+      labels:
+        app: csi-doplugin
+    spec:
+      serviceAccount: csi-doplugin
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+              # TODO(arslan): the registar is not implemented yet
+              # - name: registrar-socket-dir
+              #   mountPath: /var/lib/csi/sockets/
+        - name: csi-doplugin 
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: digitalocean/do-csi-plugin:v0.0.1
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: DIGITALOCEAN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: digitalocean
+                  key: access-token
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - mountPath: /dev
+              name: device-dir
+      volumes:
+        # TODO(arslan): the registar is not implemented yet
+        #- name: registrar-socket-dir
+        #  hostPath:
+        #    path: /var/lib/kubelet/device-plugins/
+        #    type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.digitalocean.csi.dobs
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev

--- a/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
@@ -23,6 +23,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: do-block-storage
+  namespace: kube-system
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: com.digitalocean.csi.dobs
@@ -31,11 +32,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-attacher
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-attacher-runner
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -58,6 +61,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-role
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-attacher
@@ -72,6 +76,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-attacher-doplugin
+  namespace: kube-system
   labels:
     app: csi-attacher-doplugin
 spec:
@@ -85,6 +90,7 @@ kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
   name: csi-attacher-doplugin
+  namespace: kube-system
 spec:
   serviceName: "csi-attacher-doplugin"
   replicas: 1
@@ -132,12 +138,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-provisioner
-
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -160,6 +167,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner
@@ -174,6 +182,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-provisioner-doplugin
+  namespace: kube-system
   labels:
     app: csi-provisioner-doplugin
 spec:
@@ -187,6 +196,7 @@ kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
   name: csi-provisioner-doplugin
+  namespace: kube-system
 spec:
   serviceName: "csi-provisioner-doplugin"
   replicas: 1
@@ -235,12 +245,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-doplugin
-
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-doplugin
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -262,6 +273,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-doplugin
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-doplugin
@@ -276,6 +288,7 @@ kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
   name: csi-doplugin
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -303,7 +316,7 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi/
-              # TODO(arslan): the registar is not implemented yet
+              # TODO(arslan): the registrar is not implemented yet
               # - name: registrar-socket-dir
               #   mountPath: /var/lib/csi/sockets/
         - name: csi-doplugin 

--- a/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-NOT_RELEASED_v0.0.2.yaml
@@ -65,7 +65,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: csi-attacher
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: external-attacher-runner
@@ -171,7 +171,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: external-provisioner-runner
@@ -277,7 +277,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: csi-doplugin
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-doplugin


### PR DESCRIPTION
This means that users that already have created a token for
cloud-controller-manager can use the same token for the CSI plugin

- [x] checkout namespace compatibility

Fixes #20