### PR TITLE
Add Changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## v0.1.0 (beta) (UNRELEASED)
+
+* Add method names to each log entry 
+  [[GH-22]](https://github.com/digitalocean/csi-digitalocean/pull/22)
+
+## v0.0.1 (alpha)
+
+* First release with all important methods of the CSI spec
+* implemented


### PR DESCRIPTION
We started the alpha with the patch version (0.0.1). Hence we should start the beta with (0.1.0) going forward so we have space for patches if needed. 