### PR TITLE
Updated README.md pod spec to match /example/csi-app.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,15 @@ apiVersion: v1
 metadata:
   name: my-csi-app
 spec:
-  nodeName: "nodes-2"
   containers:
     - name: my-frontend
       image: busybox
       volumeMounts:
       - mountPath: "/data"
-        name: my-csi-volume
+        name: my-do-volume
       command: [ "sleep", "1000000" ]
   volumes:
-    - name: my-csi-volume
+    - name: my-do-volume
       persistentVolumeClaim:
         claimName: csi-pvc 
 ```


### PR DESCRIPTION
This change is mainly important because of the deletion of `nodeName: "nodes-2"` from the spec. By having a `Pod` use the `nodeName` field assigned to a node that doesn't exist, the scheduler tries to create it, realizes theres no node that match it's criteria and deletes itself. By deleting that line the copy paste example is easier for users to test with. 

The other fields I updated just so it would match the example in the example directory. 