### PR TITLE
driver: check if the mounts are propagated

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -133,7 +133,13 @@ func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolu
 	})
 	ll.Info("node unstage volume called")
 
-	mounted, err := d.mounter.IsMounted("", req.StagingTargetPath)
+	vol, _, err := d.doClient.Storage.GetVolume(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	source := getDiskSource(vol.Name)
+	mounted, err := d.mounter.IsMounted(source, req.StagingTargetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -172,6 +178,14 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	}
 
 	// TODO(arslan): early return if already mounted
+
+	vol, _, err := d.doClient.Storage.GetVolume(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	diskSource := getDiskSource(vol.Name)
+
 	source := req.StagingTargetPath
 	target := req.TargetPath
 
@@ -199,7 +213,9 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		"method":        "node_publish_volume",
 	})
 
-	mounted, err := d.mounter.IsMounted(source, target)
+	// we can only check if target is mounted with the diskSource directly.
+	// The staging target path (which is a directory itself) won't work in this case
+	mounted, err := d.mounter.IsMounted(diskSource, target)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +226,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		ll.Info("volume is already mounedt")
+		ll.Info("volume is already mounted")
 	}
 
 	ll.Info("bind mounting the volume is finished")

--- a/driver/node.go
+++ b/driver/node.go
@@ -177,8 +177,6 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Volume Capability must be provided")
 	}
 
-	// TODO(arslan): early return if already mounted
-
 	vol, _, err := d.doClient.Storage.GetVolume(ctx, req.VolumeId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Make sure mount propagation is enabled. We can check it by using
`findmnt` with the `PROPAGATION` label.

Also fix an issue to check the mounted path for the target path where
checking against the staging target path won't work as findmnt only
works on devices