### PR TITLE
driver: pass the correct source to IsMounted()

### DIFF
--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -181,6 +181,14 @@ func (m *mounter) IsFormatted(source string) (bool, error) {
 }
 
 func (m *mounter) IsMounted(source, target string) (bool, error) {
+	if source == "" {
+		return false, errors.New("source is not specified for checking the mount")
+	}
+
+	if target == "" {
+		return false, errors.New("target is not specified for checking the mount")
+	}
+
 	findmntCmd := "findmnt"
 	_, err := exec.LookPath(findmntCmd)
 	if err != nil {

--- a/driver/node.go
+++ b/driver/node.go
@@ -248,7 +248,13 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	})
 	ll.Info("node unpublish volume called")
 
-	mounted, err := d.mounter.IsMounted("", req.TargetPath)
+	vol, _, err := d.doClient.Storage.GetVolume(ctx, req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	source := getDiskSource(vol.Name)
+	mounted, err := d.mounter.IsMounted(source, req.TargetPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We shouldn't pass an empty source path to IsMounted. Also make sure it's
never empty.