### PR TITLE
driver: handle non existing volumes and nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Remove description to allow users to reuse volumes that were created by the
   UI/API
   [[GH-59]](https://github.com/digitalocean/csi-digitalocean/pull/59)
+* Handle edge cases from external action, such as Volume deletion via UI more
+  gracefully. We're not very strict anymore in cases we don't need to be, but
+  we're also returning a better error in cases we need to be.
+  [[GH-60]](https://github.com/digitalocean/csi-digitalocean/pull/60)
 
 ## v0.1.3 - August 3rd 2018
 

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -187,6 +187,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
 		}
+		return nil, err
 	}
 
 	// check if droplet exist before trying to attach the volume to the droplet
@@ -195,6 +196,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "droplet %q not found", dropletID)
 		}
+		return nil, err
 	}
 
 	action, resp, err := d.doClient.StorageActions.Attach(ctx, req.VolumeId, dropletID)
@@ -247,6 +249,7 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 			// assume it's detached
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
+		return nil, err
 	}
 
 	// check if droplet exist before trying to detach the volume from the droplet
@@ -255,6 +258,7 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "droplet %q not found", dropletID)
 		}
+		return nil, err
 	}
 
 	action, resp, err := d.doClient.StorageActions.DetachByDropletID(ctx, req.VolumeId, dropletID)
@@ -314,6 +318,7 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 		if volResp != nil && volResp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
 		}
+		return nil, err
 	}
 
 	hasSupport := func(mode csi.VolumeCapability_AccessMode_Mode) bool {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -202,6 +202,6 @@ func (f *fakeMounter) Unmount(target string) error {
 func (f *fakeMounter) IsFormatted(source string) (bool, error) {
 	return true, nil
 }
-func (f *fakeMounter) IsMounted(source, target string) (bool, error) {
+func (f *fakeMounter) IsMounted(target string) (bool, error) {
 	return true, nil
 }

--- a/driver/node.go
+++ b/driver/node.go
@@ -64,6 +64,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
 		}
+		return nil, err
 	}
 
 	source := getDiskSource(vol.Name)
@@ -190,6 +191,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
 		}
+		return nil, err
 	}
 
 	diskSource := getDiskSource(vol.Name)


### PR DESCRIPTION
According to the spec we should return a `NOT_FOUND` in various method.
We always assume the volume or node exist, however this might not the
case.

For example the user might delete the volume externally from the
UI or make a HTTP call to the DigitalOcean API to delete the volume.
Actions like this are outside the Kubernetes system, so the plugin needs
to handle these edge cases by signaling back that the resources don't
exist.

We return `NOT_FOUND` for any creation actions, such as creating a
volume, attaching a volume, formatting, etc.. Because we really need to
return an error as there is no way to recover from this

We don't return `NOT_FOUND` for any destroy actions, such as deleting,
detaching, unmounting, etc.. Because in all these cases it doesn't
matter if the volume doesn't exist. There is not much to do and assuming
it's "done" makes the overall system more stable