### PR TITLE
Makefile: various improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* Makefile improvements. Please check the GH link for more information.
+  [[GH-66]](https://github.com/digitalocean/csi-digitalocean/pull/66)
+
 ## v0.1.4 - 2018.08.23
 
 * Add logs to mount operations

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ else
   GIT_TREE_STATE=dirty
 endif
 COMMIT ?= $(shell git rev-parse HEAD)
+BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 LDFLAGS ?= -X github.com/digitalocean/csi-digitalocean/driver.version=${VERSION} -X github.com/digitalocean/csi-digitalocean/driver.commit=${COMMIT} -X github.com/digitalocean/csi-digitalocean/driver.gitTreeState=${GIT_TREE_STATE}
 PKG ?= github.com/digitalocean/csi-digitalocean/cmd/do-csi-plugin
 
@@ -35,9 +36,14 @@ compile:
 	@echo "==> Building the project"
 	@env CGO_ENABLED=0 GOOS=${OS} GOARCH=amd64 go build -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG} 
 
+compile-dev:
+	@echo "==> Building the project"
+	$(eval VERSION = dev)
+	@env CGO_ENABLED=0 GOOS=${OS} GOARCH=amd64 go build -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG} 
+
 test:
 	@echo "==> Testing all packages"
-	@go test ./...
+	@go test -v ./...
 
 
 build:
@@ -46,14 +52,15 @@ build:
 
 
 push:
+
+ifneq ($(BRANCH),master)
+	@echo "ERROR: Publishing image with a SEMVER version '$(VERSION)' is only allowed from master"
+else
 	@echo "==> Publishing digitalocean/do-csi-plugin:$(VERSION)"
 	@docker push digitalocean/do-csi-plugin:$(VERSION)
 	@echo "==> Your image is now available at digitalocean/do-csi-plugin:$(VERSION)"
+endif
 
-compile-dev:
-	@echo "==> Building the project"
-	$(eval VERSION = dev)
-	@env CGO_ENABLED=0 go build -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG} 
 
 build-dev:
 	@echo "==> Building the docker image"


### PR DESCRIPTION
* Fix building image from localhost
* Add `-v` flag to `go test`
* Prevent pushing a stable image from a non-master branch

closes: #67 