### PR TITLE
driver: validate capabilities for volume creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Makefile improvements. Please check the GH link for more information.
   [[GH-66]](https://github.com/digitalocean/csi-digitalocean/pull/66)
+* Validate volume capabilities during volume creation.
+  [[GH-68]](https://github.com/digitalocean/csi-digitalocean/pull/68)
 
 ## v0.1.4 - 2018.08.23
 


### PR DESCRIPTION
We don't validate the capabilities during `CreateVolume()`. We should
start doing it to avoid creating volumes that need to be in different
modes, such as `MULTI_NODE_MULTI_WRITER` (ReadWriteMany in k8s) or
`MULTI_NODE_READER_ONLY` (ReadOnlyMany in k8s)

Note that, there is a [bug](https://github.com/kubernetes-csi/external-provisioner/issues/117) in the `external-provisioner` sidecar that passes down the Kubernetes `accessModes` fields to the CSI plugin. It currently passes a hardcoded value of `SINGLE_NODE_WRITER` (see: https://github.com/kubernetes-csi/externalprovisioner/blob/4d8a86cc54901d4d14b56c03a6ee7dfe6482c9b1/pkg/controller/controller.go#L89), so this means currently it's not possible to create volumes with `ReadWriteMany` or `ReadOnlyMany` nevertheless.

But it's good we have the check in place, so we're protected once the
issue in the provisioner is fixed in the future.

closes #42