### PR TITLE
csi: use publish_info for storing and accessing the volume name

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -41,6 +41,8 @@ const (
 )
 
 const (
+	PublishInfoVolumeName = "com.digitalocean.csi/volume-name"
+
 	defaultVolumeSizeInGB = 16 * GB
 
 	createdByDO = "Created by DigitalOcean CSI driver"
@@ -253,7 +255,11 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		attachedID = id
 		if id == dropletID {
 			ll.Info("volume is already attached")
-			return &csi.ControllerPublishVolumeResponse{}, nil
+			return &csi.ControllerPublishVolumeResponse{
+				PublishInfo: map[string]string{
+					PublishInfoVolumeName: vol.Name,
+				},
+			}, nil
 		}
 	}
 
@@ -273,7 +279,11 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 					"error": err,
 					"resp":  resp,
 				}).Warn("assuming volume is attached already")
-				return &csi.ControllerPublishVolumeResponse{}, nil
+				return &csi.ControllerPublishVolumeResponse{
+					PublishInfo: map[string]string{
+						PublishInfoVolumeName: vol.Name,
+					},
+				}, nil
 			}
 
 			if strings.Contains(err.Error(), "Droplet already has a pending event") {
@@ -297,7 +307,11 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	}
 
 	ll.Info("volume is attached")
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return &csi.ControllerPublishVolumeResponse{
+		PublishInfo: map[string]string{
+			PublishInfoVolumeName: vol.Name,
+		},
+	}, nil
 }
 
 // ControllerUnpublishVolume deattaches the given volume from the node

--- a/driver/node.go
+++ b/driver/node.go
@@ -26,7 +26,6 @@ package driver
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
@@ -66,15 +65,14 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume Capability must be provided")
 	}
 
-	vol, resp, err := d.doClient.Storage.GetVolume(ctx, req.VolumeId)
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
-		}
-		return nil, err
+	volumeName := ""
+	if volName, ok := req.GetPublishInfo()[PublishInfoVolumeName]; !ok {
+		return nil, status.Error(codes.InvalidArgument, "Could not find the volume by name")
+	} else {
+		volumeName = volName
 	}
 
-	source := getDiskSource(vol.Name)
+	source := getDiskSource(volumeName)
 	target := req.StagingTargetPath
 
 	mnt := req.VolumeCapability.GetMount()
@@ -87,7 +85,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	ll := d.log.WithFields(logrus.Fields{
 		"volume_id":           req.VolumeId,
-		"volume_name":         vol.Name,
+		"volume_name":         volumeName,
 		"volume_attributes":   req.VolumeAttributes,
 		"staging_target_path": req.StagingTargetPath,
 		"source":              source,


### PR DESCRIPTION
After tracing through a bunch of the CSI code, I came to the conclusion that this could be a viable strategy for doing away with the need for the nodes to call the API to fetch the volume name.

Super open to feedback here, I've verified that this does indeed work by running the integration test suite against a cluster with my custom build deployed on it for CSI.