### PR TITLE
csi: fix incosistent driver name usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Fix inconsistent usage of the driver name
+  [[GH-100]](https://github.com/digitalocean/csi-digitalocean/pull/100)
 * Use publish_info in ControllerPublishVolume for storing and accessing the
   volume name on Node plugins. This allows us to do all Node related operations
   without relying on the DO API.

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -27,7 +27,7 @@ import (
 
 func main() {
 	var (
-		endpoint = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/com.digitalocean.csi.dobs/csi.sock", "CSI endpoint")
+		endpoint = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DriverName+"/csi.sock", "CSI endpoint")
 		token    = flag.String("token", "", "DigitalOcean access token")
 		url      = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
 		version  = flag.Bool("version", false, "Print the version and exit.")

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -41,10 +41,15 @@ const (
 )
 
 const (
-	PublishInfoVolumeName = "com.digitalocean.csi/volume-name"
+	// PublishInfoVolumeName is used to pass the volume name from
+	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
+	PublishInfoVolumeName = DriverName + "/volume-name"
 
+	// defaultVolumeSizeInGB is used when the user didn't defined a correct
+	// storage size or if the size is not satisfised
 	defaultVolumeSizeInGB = 16 * GB
 
+	// createdByDO is used to tag volumes that are created by this CSI plugin
 	createdByDO = "Created by DigitalOcean CSI driver"
 )
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,7 +36,9 @@ import (
 )
 
 const (
-	driverName = "dobs.csi.digitalocean.com"
+	// DriverName defines the name that is used in Kubernetes and the CSI
+	// system for the canonical, official name of this plugin
+	DriverName = "dobs.csi.digitalocean.com"
 )
 
 var (

--- a/driver/identity.go
+++ b/driver/identity.go
@@ -27,7 +27,7 @@ import (
 // GetPluginInfo returns metadata of the plugin
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	resp := &csi.GetPluginInfoResponse{
-		Name:          driverName,
+		Name:          DriverName,
 		VendorVersion: version,
 	}
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -44,7 +44,7 @@ const (
 	// This annotation is added to a PV to indicate that the volume should be
 	// not formatted. Useful for cases if the user wants to reuse an existing
 	// volume.
-	annNoFormatVolume = "com.digitalocean.csi/noformat"
+	annNoFormatVolume = DriverName + "/noformat"
 )
 
 // NodeStageVolume mounts the volume to a staging path on the node. This is

--- a/examples/kubernetes/pod-single-existing-volume/README.md
+++ b/examples/kubernetes/pod-single-existing-volume/README.md
@@ -27,7 +27,7 @@ metadata:
   annotations:
     # fake it by indicating this is provisioned dynamically, so the system
     # works properly
-    pv.kubernetes.io/provisioned-by: com.digitalocean.csi.dobs
+    pv.kubernetes.io/provisioned-by: dobs.csi.digitalocean.com
 spec:
   storageClassName: do-block-storage
   # by default, the volume will be not deleted if you delete the PVC, change to
@@ -38,7 +38,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   csi:
-    driver: com.digitalocean.csi.dobs
+    driver: dobs.csi.digitalocean.com
     fsType: ext4
     volumeHandle: 1952d58a-c714-11e8-bc0c-0a58ac14421e
     volumeAttributes:

--- a/examples/kubernetes/pod-single-existing-volume/pv.yaml
+++ b/examples/kubernetes/pod-single-existing-volume/pv.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     # fake it by indicating this is provisioned dynamically, so the system
     # works properly
-    pv.kubernetes.io/provisioned-by: com.digitalocean.csi.dobs
+    pv.kubernetes.io/provisioned-by: dobs.csi.digitalocean.com
 spec:
   storageClassName: do-block-storage
   # by default, the volume will be not deleted if you delete the PVC, change to
@@ -16,7 +16,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   csi:
-    driver: com.digitalocean.csi.dobs
+    driver: dobs.csi.digitalocean.com
     fsType: ext4
     volumeHandle: 1952d58a-c714-11e8-bc0c-0a58ac14421e
     volumeAttributes:


### PR DESCRIPTION
Our driver name has changed from `com.digitalocean.csi.dobs` to
`dobs.csi.digitalocean.com` because of the upcoming changes to the CSI
spec that decided to follow a forward domain notation instead of reverse
domain notation.

Seems like the names were incorrect in many places and we also forget to
update it in various places. I made sure to export `driver.DriverName`
and use that variable everywhere in the code. So in the future, if we
need to change it again, we'll make sure it's updated correctly from a
single place.