### PR TITLE
deploy: add VolumeSnapshot CRD's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   [[GH-103]](https://github.com/digitalocean/csi-digitalocean/pull/103)
 * Add csi-snapshotter sidecars and associated RBAC rules
   [[GH-104]](https://github.com/digitalocean/csi-digitalocean/pull/104)
+* Add VolumeSnapshot CRD's to simplify the driver installation
+  [[GH-108]](https://github.com/digitalocean/csi-digitalocean/pull/108)
 * Revisit existing RBAC rules for the attacher, provisioner and
   driver-registrar. We no longer use the system cluster-role bindings as those
   will be deleted in v1.13
@@ -17,6 +19,7 @@
 * Improve creating volumes by validating the storage size requirements stricter
   and returning more human friendly errors.
   [[GH-101]](https://github.com/digitalocean/csi-digitalocean/pull/101)
+
 
 ## v0.3.1 - 2018.10.31
 

--- a/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
@@ -20,6 +20,12 @@
 
 ---
 
+####################################################
+###########                             ############
+###########  CSI Node and Driver CRDs   ############
+###########                             ############
+####################################################
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -107,6 +113,72 @@ spec:
 
 ---
 
+##############################################
+###########                       ############
+###########     Snapshot CRDs     ############
+###########                       ############
+##############################################
+#
+# The following CRD's are created by the csi-snapshotter, however it
+# complicates installing a driver, because we're not able to install a custom
+# VolumeSnapshotClass until the csi-snapshotter sidecar is up and running.  We
+# pulled out the CRD's and put them here to simplify the installation for the
+# users. Make sure these are up to date with the original ones whenever we
+# release a new version: https://github.com/kubernetes-csi/external-snapshotter/blob/master/cmd/csi-snapshotter/create_crd.go
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    plural: volumesnapshotclasses
+  scope: Cluster
+  version: v1alpha1
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    plural: volumesnapshotcontents
+  scope: Cluster
+  version: v1alpha1
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    plural: volumesnapshots
+  scope: Namespaced
+  version: v1alpha1
+
+---
+
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+metadata:
+  name: do-block-storage
+  namespace: kube-system
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+snapshotter: dobs.csi.digitalocean.com
+
+---
+
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -118,19 +190,6 @@ provisioner: dobs.csi.digitalocean.com
 
 ---
 
-# NOTE(arslan): this will probably fail , because the CRD is created via the
-# csi-snapshotter sidecar, that is part of the csi-do-controller statefulset.
-# We need to create this seperately.
-kind: VolumeSnapshotClass
-apiVersion: snapshot.storage.k8s.io/v1alpha1
-metadata:
-  name: do-block-storage
-  namespace: kube-system
-  annotations:
-    snapshot.storage.kubernetes.io/is-default-class: "true"
-snapshotter: dobs.csi.digitalocean.com
-
----
 
 ##############################################
 ###########                       ############


### PR DESCRIPTION
The following CRD's are created by the csi-snapshotter, however it
complicates installing a driver, because we're not able to install a custom
VolumeSnapshotClass until the csi-snapshotter sidecar is up and running.

We pulled out the CRD's and put them here to simplify the installation
for the users. We need to make sure these are up to date with the
original ones whenever we release a new version:
https://github.com/kubernetes-csi/external-snapshotter/blob/master/cmd/csi-snapshotter/create_crd.go