### PR TITLE
Add priorityClassName to controller and node plugin

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
@@ -211,6 +211,7 @@ spec:
         app: csi-do-controller
         role: csi-do
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
@@ -431,6 +432,7 @@ spec:
         app: csi-do-node
         role: csi-do
     spec:
+      priorityClassName: system-node-critical
       serviceAccount: csi-do-node-sa
       hostNetwork: true
       containers:

--- a/deploy/kubernetes/releases/csi-digitalocean-v0.2.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v0.2.0.yaml
@@ -51,6 +51,7 @@ spec:
         app: csi-do-controller
         role: csi-do
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
@@ -165,6 +166,7 @@ spec:
         app: csi-do-node
         role: csi-do
     spec:
+      priorityClassName: system-node-critical
       serviceAccount: csi-do-node-sa
       hostNetwork: true
       containers:

--- a/deploy/kubernetes/releases/csi-digitalocean-v0.3.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v0.3.0.yaml
@@ -138,6 +138,7 @@ spec:
         app: csi-do-controller
         role: csi-do
     spec:
+      priortyClassName: system-cluster-critical
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
@@ -252,6 +253,7 @@ spec:
         app: csi-do-node
         role: csi-do
     spec:
+      priorityClassName: system-node-critical
       serviceAccount: csi-do-node-sa
       hostNetwork: true
       containers:

--- a/deploy/kubernetes/releases/csi-digitalocean-v0.3.1.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v0.3.1.yaml
@@ -138,6 +138,7 @@ spec:
         app: csi-do-controller
         role: csi-do
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
@@ -252,6 +253,7 @@ spec:
         app: csi-do-node
         role: csi-do
     spec:
+      priorityClassName: system-node-critical
       serviceAccount: csi-do-node-sa
       hostNetwork: true
       containers:

--- a/deploy/kubernetes/releases/csi-digitalocean-v0.4.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v0.4.0.yaml
@@ -211,6 +211,7 @@ spec:
         app: csi-do-controller
         role: csi-do
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
@@ -430,6 +431,7 @@ spec:
         app: csi-do-node
         role: csi-do
     spec:
+      priorityClassName: system-node-critical
       serviceAccount: csi-do-node-sa
       hostNetwork: true
       containers:


### PR DESCRIPTION
This should help prevent the CSI components from being evicted in favor of user workloads, unless they are explicitly given higher priority.

I didn't include these changes to the `0.1.x` releases since those are likely associated with 1.10.x clusters where this may or may not be enabled.