### PR TITLE
Remove debug code that causes warnings on nodes

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -159,12 +159,6 @@ func (d *Driver) Run() error {
 		return resp, err
 	}
 
-	// warn the user, it'll not propagate to the user but at least we see if
-	// something is wrong in the logs
-	if err := d.checkLimit(context.Background()); err != nil {
-		d.log.WithError(err).Warn("CSI plugin will not function correctly, please resolve volume limit")
-	}
-
 	d.srv = grpc.NewServer(grpc.UnaryInterceptor(errHandler))
 	csi.RegisterIdentityServer(d.srv, d)
 	csi.RegisterControllerServer(d.srv, d)


### PR DESCRIPTION
We're currently getting the following error on all nodes when the plugin boots up:

```
time="2019-01-14T20:13:52Z" level=warning msg="CSI plugin will not function correctly, please resolve volume limit" error="rpc error: code = Internal desc = couldn't get account information to check volume limit: GET https://api.digitalocean.com/v2/account: 401 Unable to authenticate you."
```

This is because the worker nodes don't have a DigitalOcean access token (because they don't need one) and thus can't access the API. This seems to be some leftover debugging code, so it should be safe to remove.