### PR TITLE
driver: don't check limits on worker nodes

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -54,11 +54,11 @@ var (
 //   csi.NodeServer
 //
 type Driver struct {
-	endpoint string
-	nodeId   string
-	region   string
-	doTag    string
-	hasToken bool
+	endpoint     string
+	nodeId       string
+	region       string
+	doTag        string
+	isController bool
 
 	srv     *grpc.Server
 	log     *logrus.Entry
@@ -115,7 +115,9 @@ func NewDriver(ep, token, url, doTag string) (*Driver, error) {
 		region:   region,
 		mounter:  newMounter(log),
 		log:      log,
-		hasToken: token != "",
+		// for now we're assuming only the controller has a non-empty token. In
+		// the future we should pass an explicit flag to the driver.
+		isController: token != "",
 
 		storage:        doClient.Storage,
 		storageActions: doClient.StorageActions,
@@ -167,7 +169,7 @@ func (d *Driver) Run() error {
 	// warn the user, it'll not propagate to the user but at least we see if
 	// something is wrong in the logs. Only check if the driver is running with
 	// a token (i.e: controller)
-	if d.hasToken {
+	if d.isController {
 		if err := d.checkLimit(context.Background()); err != nil {
 			d.log.WithError(err).Warn("CSI plugin will not function correctly, please resolve volume limit")
 		}


### PR DESCRIPTION
We're checking the volume limit during the driver startup. However
because the driver is used both for the controller and node part, it
fails during the node startup because we're deploying the driver to the
nodes without a token. The DO token is only needed by the controller.

The `checkLimit()` function would therefore print when deployed to the
nodes:

```
time="2019-01-14T20:13:52Z" level=warning msg="CSI plugin will not
function correctly, please resolve volume limit" error="rpc error: code
= Internal desc = couldn't get account information to check volume
limit: GET https://api.digitalocean.com/v2/account: 401 Unable to
authenticate you."
```

This PR fixes that to not to call `checkLimit` if the token is not
passed, which is a valid case for drivers deployed to the worker nodes.

supersedes #127