### PR TITLE
Fix races in snapshot integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   [[GH-142]](https://github.com/digitalocean/csi-digitalocean/pull/142)
 * Update `godo` (DigitalOcean API package) version to v1.13.0
   [[GH-143]](https://github.com/digitalocean/csi-digitalocean/pull/143)
+* Fix race in snapshot integration test.
+  [[GH-146]](https://github.com/digitalocean/csi-digitalocean/pull/146)
 
 ## v1.0.0 - 2018.12.19
 

--- a/test/kubernetes/integration_test.go
+++ b/test/kubernetes/integration_test.go
@@ -358,6 +358,24 @@ func TestSnapshot_Create(t *testing.T) {
 			Name: "my-csi-app-2",
 		},
 		Spec: v1.PodSpec{
+			// Write the data in an InitContainer so that we can guarantee
+			// it's been written before we reach running in the main container.
+			InitContainers: []v1.Container{
+				{
+					Name:  "my-csi",
+					Image: "busybox",
+					VolumeMounts: []v1.VolumeMount{
+						{
+							MountPath: "/data",
+							Name:      volumeName,
+						},
+					},
+					Command: []string{
+						"sh", "-c",
+						"echo testcanary > /data/canary && sync",
+					},
+				},
+			},
 			Containers: []v1.Container{
 				{
 					Name:  "my-csi-app",
@@ -370,7 +388,7 @@ func TestSnapshot_Create(t *testing.T) {
 					},
 					Command: []string{
 						"sh", "-c",
-						"echo testcanary > /data/canary && sleep 1000000",
+						"sleep 1000000",
 					},
 				},
 			},


### PR DESCRIPTION
This test failed more often than not in my local testing. Previously we only waited for the pod to be running which didn't guarantee the file had been created, nor that it had been sync'ed to the block device.