### PR TITLE
bump-version: remove sembump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 LDFLAGS ?= -X github.com/digitalocean/csi-digitalocean/driver.version=${VERSION} -X github.com/digitalocean/csi-digitalocean/driver.commit=${COMMIT} -X github.com/digitalocean/csi-digitalocean/driver.gitTreeState=${GIT_TREE_STATE}
 PKG ?= github.com/digitalocean/csi-digitalocean/cmd/do-csi-plugin
 
-## Bump the version in the version file. Set BUMP to [ major | minor | patch ]
-BUMP := patch
 VERSION ?= $(shell cat VERSION)
 
 all: test
@@ -20,8 +18,8 @@ publish: compile build push clean
 
 .PHONY: bump-version
 bump-version: 
-	@go get -u github.com/jessfraz/junk/sembump # update sembump tool
-	$(eval NEW_VERSION = $(shell sembump --kind $(BUMP) $(VERSION)))
+	@[ "${NEW_VERSION}" ] || ( echo "NEW_VERSION must be set (ex. make NEW_VERSION=v1.x.x bump-version)"; exit 1 )
+	@(echo ${NEW_VERSION} | grep -E "^v") || ( echo "NEW_VERSION must be a semver ('v' prefix is required)"; exit 1 )
 	@echo "Bumping VERSION from $(VERSION) to $(NEW_VERSION)"
 	@echo $(NEW_VERSION) > VERSION
 	@cp deploy/kubernetes/releases/csi-digitalocean-${VERSION}.yaml deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ bumped following the rules below:
   </thead>
   <tbody>
     <tr>
-      <td>v0.1.0 - v0.2.x</td>
+      <td>v0.1.x - v0.2.x</td>
       <td>yes</td>
       <td>no</td>
       <td>no</td>
     </tr>
     <tr>
-      <td>v0.3.0 - v0.4.x</td>
+      <td>v0.3.x - v0.4.x</td>
       <td>no</td>
       <td>yes</td>
       <td>no</td>
     </tr>
     <tr>
-      <td>v1.0.0 - v1.0.x</td>
+      <td>v1.0.x - v1.0.x</td>
       <td>no</td>
       <td>no</td>
       <td>yes</td>
@@ -226,7 +226,7 @@ Dependencies are managed via [Go modules](https://github.com/golang/go/wiki/Modu
 To release a new version bump first the version:
 
 ```
-$ make bump-version
+$ make NEW_VERSION=v1.0.0 bump-version
 ```
 
 Make sure everything looks good. Create a new branch with all changes:


### PR DESCRIPTION
- sembump (github.com/jessfraz/junk/sembump) is unsupported by
  the author and won't build on mac/windows. Make NEW_VERSION explicit.
```
make bump-version
...
go: extracting github.com/jessfraz/junk v0.0.0-20180914164745-9ae1b9618feb
-> unzip /Users/cbaker/go/src/github.internal.digitalocean.com/digitalocean/cthulhu/docode/pkg/mod/cache/download/github.com/jessfraz/junk/@v/v0.0.0-20180914164745-9ae1b9618feb.zip: case-insensitive file name collision: "md2pdf/VERSION" and "md2pdf/version"
go get github.com/jessfraz/junk/sembump: unzip /Users/cbaker/go/src/github.internal.digitalocean.com/digitalocean/cthulhu/docode/pkg/mod/cache/download/github.com/jessfraz/junk/@v/v0.0.0-20180914164745-9ae1b9618feb.zip: case-insensitive file name collision: "md2pdf/VERSION" and "md2pdf/version"
```
- make ... bump-version manged the low-version on the compatibility table.