### PR TITLE
driver: return proper error messages instead

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -811,7 +810,10 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 }
 
 func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	return nil, errors.New("not implemented yet")
+	d.log.WithField("method", "controller_expand_volume").
+		Info("controller expand volume called")
+
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // extractStorage extracts the storage size in bytes from the given capacity

--- a/driver/node.go
+++ b/driver/node.go
@@ -26,7 +26,6 @@ package driver
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -322,7 +321,10 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 }
 
 func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	return nil, errors.New("not implemented yet")
+	d.log.WithField("method", "node_expand_volume").
+		Info("node expand volume called")
+
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // getDiskSource returns the absolute path of the attached volume for the given


### PR DESCRIPTION
We should return gRPC error types instead of a generic one