### PR TITLE
Set a custom user agent for the godo client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Set a custom user agent for the godo client. [[GH-156](https://github.com/digitalocean/csi-digitalocean/pull/156)]
+
 ## v1.1.0 - 2019.04.29
 
 **IMPORTANT**: This release is only compatible with Kubernetes **`v1.14.+`**

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -97,6 +97,11 @@ func NewDriver(ep, token, url, doTag string) (*Driver, error) {
 	opts := []godo.ClientOpt{}
 	opts = append(opts, godo.SetBaseURL(url))
 
+	if version == "" {
+		version = "dev"
+	}
+	opts = append(opts, godo.SetUserAgent("csi-digitalocean/"+version))
+
 	doClient, err := godo.New(oauthClient, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't initialize DigitalOcean client: %s", err)


### PR DESCRIPTION
Currently, requests made by the csi-digitalocean driver send `godo/$godoVersion` as their user agent. This change updates the user agent to use the format `csi-digitalocean/$csiVersion godo/$godoVersion` in order to help us better understand godo usage.