### PR TITLE
Add missing access token references to v1.1.0 Kubernetes release

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-v1.1.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.1.0.yaml
@@ -179,6 +179,11 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: DIGITALOCEAN_API_URL
               value: https://api.digitalocean.com/
+            - name: DIGITALOCEAN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: digitalocean
+                  key: access-token
           imagePullPolicy: "Always"
           volumeMounts:
             - name: socket-dir
@@ -381,6 +386,7 @@ spec:
           image: digitalocean/do-csi-plugin:v1.1.0
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
+            - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
             - "--url=$(DIGITALOCEAN_API_URL)"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/kubernetes/releases/csi-digitalocean-v1.1.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.1.0.yaml
@@ -386,7 +386,6 @@ spec:
           image: digitalocean/do-csi-plugin:v1.1.0
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
             - "--url=$(DIGITALOCEAN_API_URL)"
           env:
             - name: CSI_ENDPOINT


### PR DESCRIPTION
This is a straightforward change that adds the access token references missing from the v1.1.10 Kubernetes release definition. Resolves #158 and probably #155.