### PR TITLE
Support XFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 * Set a custom user agent for the godo client. [[GH-156](https://github.com/digitalocean/csi-digitalocean/pull/156)]
+* Include `xfsprogs` in the base Docker image so that XFS can be used
 
 ## v1.1.0 - 2019.04.29
 

--- a/cmd/do-csi-plugin/Dockerfile
+++ b/cmd/do-csi-plugin/Dockerfile
@@ -14,7 +14,10 @@
 
 FROM alpine:3.7
 
-RUN apk add --no-cache ca-certificates e2fsprogs findmnt
+RUN apk add --no-cache ca-certificates \
+                       e2fsprogs \
+                       findmnt \
+                       xfsprogs
 
 ADD do-csi-plugin /bin/
 


### PR DESCRIPTION
Include `xfsprogs` in the base Docker image so that XFS can be used.

Also validated in https://github.com/snormore/doks-examples/tree/master/xfs