### PR TITLE
Fix 'publish' make target for release-1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build:
 
 .PHONY: push
 push:
-ifeq ($(shell [[ $(BRANCH) != "master" && $(VERSION) != "dev" ]] && echo true ),true)
+ifeq ($(shell [[ $(BRANCH) != "release-1.0" && $(VERSION) != "dev" ]] && echo true ),true)
 	@echo "ERROR: Publishing image with a SEMVER version '$(VERSION)' is only allowed from master"
 else
 	@echo "==> Publishing digitalocean/do-csi-plugin:$(VERSION)"


### PR DESCRIPTION
Checking the current branch name is pointless because a branch can point to a
ref that doesn't correspond to the current github release.  Instead we should
be validating

* That the current work tree is clean
* That the upstream/origin remote points to https://github.com/digitalocean/csi-digitalocean
* That the local tag refs match the upstream remote's tag refs
* That the current git head matches the sha of tag corresponding to the version
  shown in the VERSION file (after fetching tags of course).

For now, fix this by adjusting the required branch name -- I just wanted to move forward
with the release for now and this is the quickest way to do that. I'll file a
Jira ticket to track improvements to this release process.