### PR TITLE
Fix upstream CSI component versions

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-v1.1.1.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.1.1.yaml
@@ -134,7 +134,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.1
+          image: quay.io/k8scsi/csi-provisioner:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.1
+          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -359,7 +359,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.1
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
These versions were mistakenly included in the update for do-csi-plugin v1.1.1 (#166).

This updates the manifest to the same versions that we use when building our internal droplet images used for DOKS. They have been tested together with do-csi-plugin v1.1.1 in our internal release automation which runs Sonobuoy conformance tests against test clusters.