### PR TITLE
Improve error message for incorrectly attached volumes

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -313,7 +313,8 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	// droplet is attached to a different node, return an error
 	if attachedID != 0 {
 		return nil, status.Errorf(codes.FailedPrecondition,
-			"volume is attached to the wrong droplet(%q), dettach the volume to fix it", attachedID)
+			"volume %q is attached to the wrong droplet (%q), detach the volume to fix it",
+			req.VolumeId, attachedID)
 	}
 
 	// attach the volume to the correct node


### PR DESCRIPTION
Add the volume ID to the error message we return when a volume is already attached to the wrong droplet. This makes it easier to find the right volume to detach manually. Also fix the spelling of "detach".