### PR TITLE
Allow a custom driver name to be specified on the commandline (1.0 version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ $ kubectl exec -ti my-csi-app /bin/sh
 hello-world
 ```
 
+## Upgrading
+
+When upgrading to a new Kubernetes minor version, you should upgrade the CSI
+driver to match. See the table above for which driver version is used with each
+Kubernetes version.
+
+Special consideration is necessary when upgrading from Kubernetes 1.11 or
+earlier, which uses CSI driver version 0.2 or earlier. In these early releases,
+the driver name was `com.digitalocean.csi.dobs`, while in all subsequent
+releases it is `dobs.csi.digitalocean.com`. When upgrading, use the commandline
+flag `--driver-name` to force the new driver to use the old name. Failing to do
+so will cause any existing PVs to be unusable since the new driver will not
+manage them and the old driver is no longer running.
+
 ## Development
 
 Requirements:

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -27,11 +27,12 @@ import (
 
 func main() {
 	var (
-		endpoint = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DriverName+"/csi.sock", "CSI endpoint")
-		token    = flag.String("token", "", "DigitalOcean access token")
-		url      = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
-		doTag    = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach")
-		version  = flag.Bool("version", false, "Print the version and exit.")
+		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint")
+		token      = flag.String("token", "", "DigitalOcean access token")
+		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
+		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach")
+		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver")
+		version    = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -40,7 +41,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag)
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -41,10 +41,6 @@ const (
 )
 
 const (
-	// PublishInfoVolumeName is used to pass the volume name from
-	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
-	PublishInfoVolumeName = DriverName + "/volume-name"
-
 	// minimumVolumeSizeInBytes is used to validate that the user is not trying
 	// to create a volume that is smaller than what we support
 	minimumVolumeSizeInBytes int64 = 1 * giB
@@ -294,7 +290,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 			ll.Info("volume is already attached")
 			return &csi.ControllerPublishVolumeResponse{
 				PublishContext: map[string]string{
-					PublishInfoVolumeName: vol.Name,
+					d.publishInfoVolumeName: vol.Name,
 				},
 			}, nil
 		}
@@ -318,7 +314,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 				}).Warn("assuming volume is attached already")
 				return &csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{
-						PublishInfoVolumeName: vol.Name,
+						d.publishInfoVolumeName: vol.Name,
 					},
 				}, nil
 			}
@@ -346,7 +342,7 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	ll.Info("volume is attached")
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{
-			PublishInfoVolumeName: vol.Name,
+			d.publishInfoVolumeName: vol.Name,
 		},
 	}, nil
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -69,6 +69,7 @@ func TestDriverSuite(t *testing.T) {
 	}
 
 	driver := &Driver{
+		name:     DefaultDriverName,
 		endpoint: endpoint,
 		nodeId:   strconv.Itoa(nodeID),
 		doTag: doTag,

--- a/driver/identity.go
+++ b/driver/identity.go
@@ -27,7 +27,7 @@ import (
 // GetPluginInfo returns metadata of the plugin
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	resp := &csi.GetPluginInfoResponse{
-		Name:          DriverName,
+		Name:          d.name,
 		VendorVersion: version,
 	}
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -40,11 +40,18 @@ const (
 
 	// See: https://www.digitalocean.com/docs/volumes/overview/#limits
 	maxVolumesPerNode = 7
+)
 
+var (
 	// This annotation is added to a PV to indicate that the volume should be
 	// not formatted. Useful for cases if the user wants to reuse an existing
-	// volume.
-	annNoFormatVolume = DriverName + "/noformat"
+	// volume. We support using either the legacy driver name
+	// (com.digitalocean.csi.dobs) or the modern driver name
+	// (dobs.csi.digitalocean.com).
+	annsNoFormatVolume = []string{
+		"dobs.csi.digitalocean.com/no-format",
+		"com.digitalocean.csi.dobs/no-format",
+	}
 )
 
 // NodeStageVolume mounts the volume to a staging path on the node. This is
@@ -66,7 +73,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	volumeName := ""
-	if volName, ok := req.GetPublishContext()[PublishInfoVolumeName]; !ok {
+	if volName, ok := req.GetPublishContext()[d.publishInfoVolumeName]; !ok {
 		return nil, status.Error(codes.InvalidArgument, "Could not find the volume by name")
 	} else {
 		volumeName = volName
@@ -95,8 +102,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		"method":              "node_stage_volume",
 	})
 
-	_, ok := req.VolumeContext[annNoFormatVolume]
-	if !ok {
+	var noFormat bool
+	for _, ann := range annsNoFormatVolume {
+		_, noFormat = req.VolumeContext[ann]
+		if noFormat {
+			break
+		}
+	}
+	if noFormat {
+		ll.Info("skipping formatting the source device")
+	} else {
 		formatted, err := d.mounter.IsFormatted(source)
 		if err != nil {
 			return nil, err
@@ -111,8 +126,6 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			ll.Info("source device is already formatted")
 		}
 
-	} else {
-		ll.Info("skipping formatting the source device")
 	}
 
 	ll.Info("mounting the volume for staging")


### PR DESCRIPTION
The name of our CSI driver changed between the 0.2 and 0.4 releases, from `com.digitalocean.csi.dobs` to `dobs.csi.digitalocean.com`. This means that when upgrading a cluster from Kubernetes 1.11 (which uses CSI plugin 0.2) to Kubernetes 1.12 (which uses CSI plugin 0.4) volumes created before the upgrade have the old driver name in various annotations and spec fields. This prevents the new driver from managing the volume, leading to broken workloads.

To handle the upgrade case, allow a custom driver name to be specified on the commandline. This way, a cluster that was once running 1.11 and thus uses the old name can continue using the old name. By default the new name will be used.

Note: This is the same change as #179, but applied to the 1.0 branch for use in Kubernetes 1.13.