### PR TITLE
Fix the noformat annotation key

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -49,8 +49,8 @@ var (
 	// (com.digitalocean.csi.dobs) or the modern driver name
 	// (dobs.csi.digitalocean.com).
 	annsNoFormatVolume = []string{
-		"dobs.csi.digitalocean.com/no-format",
-		"com.digitalocean.csi.dobs/no-format",
+		"dobs.csi.digitalocean.com/noformat",
+		"com.digitalocean.csi.dobs/noformat",
 	}
 )
 


### PR DESCRIPTION
In #179 we changed the `noformat` annotation to `no-format`, which was not intentional. Change it back so it works as before.