### PR TITLE
Make it easy to test CSI driver changes using a DOKS cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ compile:
 	@echo "==> Building the project"
 	@docker run --rm -it -e GOOS=${OS} -e GOARCH=amd64 -v ${PWD}/:/app -w /app golang:1.12-alpine sh -c 'apk add git && go build -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG}'
 
-
 .PHONY: test
 test:
 	@echo "==> Testing all packages"
@@ -43,10 +42,8 @@ test:
 
 .PHONY: test-integration
 test-integration:
-
 	@echo "==> Started integration tests"
-	@env go test -v -tags integration ./test/...
-
+	@env go test -count 1 -v -tags integration ./test/...
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -238,12 +238,8 @@ $ VERSION=dev make publish
 This will create a binary with version `dev` and docker image pushed to
 `digitalocean/do-csi-plugin:dev`
 
-
-To run the integration tests run the following:
-
-```
-$ KUBECONFIG=$(pwd)/kubeconfig make test-integration
-```
+To run the integration tests on a DOKS cluster, follow
+[these instructions](test/kubernetes/deploy/README.md).
 
 Dependencies are managed via [Go modules](https://github.com/golang/go/wiki/Modules).
 

--- a/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
@@ -179,6 +179,11 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: DIGITALOCEAN_API_URL
               value: https://api.digitalocean.com/
+            - name: DIGITALOCEAN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: digitalocean
+                  key: access-token
           imagePullPolicy: "Always"
           volumeMounts:
             - name: socket-dir
@@ -387,11 +392,6 @@ spec:
               value: unix:///csi/csi.sock
             - name: DIGITALOCEAN_API_URL
               value: https://api.digitalocean.com/
-            - name: DIGITALOCEAN_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: digitalocean
-                  key: access-token
           imagePullPolicy: "Always"
           securityContext:
             privileged: true

--- a/test/kubernetes/deploy/README.md
+++ b/test/kubernetes/deploy/README.md
@@ -1,0 +1,54 @@
+# Deploying and Testing a Development Version
+
+The most convenient way to test changes to csi-digitalocean is on a
+[DigitalOcean Kubernetes (DOKS)](https://www.digitalocean.com/products/kubernetes/)
+cluster. However, since DOKS clusters run the DigitalOcean CSI controller as a
+managed component that cannot be modified by the user, deploying with the
+example manifests will not work.
+
+To test a development version on a DOKS cluster, do the following:
+
+1. Create a DOKS cluster on the latest version:
+   ```console
+   $ doctl k8s cluster create csi-integration-test
+   Notice: cluster is provisioning, waiting for cluster to be running
+   ..
+   ```
+   Wait for it to finish creating; your kubeconfig will automatically be updated.
+
+2. Build and push a dev version of csi-digitalocean by running `VERSION=dev make publish`
+   from the root of the repository.
+
+3. Run `deploy.sh` from this directory, providing a DO API access token for your
+   account:
+   ```console
+   $ DIGITALOCEAN_ACCESS_TOKEN=<token> ./deploy.sh
+   Deploying a dev version of the CSI driver to context do-nyc1-csi-integration-test.
+   Continue? (yes/no)
+   yes
+   ```
+   This requires [`kustomize`](https://github.com/kubernetes-sigs/kustomize) and `kubectl`.
+
+4. Run the integration tests from the repository root against the dev storage class:
+   ```console
+   $ TEST_STORAGE_CLASS=do-block-storage-dev make test-integration
+   ```
+
+## Alternative Image Locations
+
+The instructions above assume you have push access to the
+`digitalocean/do-csi-plugin` repository on Docker Hub. However, this is not
+necessary to build and test a dev version of the CSI driver.
+
+To build and publish a test version in your own image repository, do the
+following from the root of the repository:
+
+```console
+$ DOCKER_REPO=<my-image-repository> VERSION=dev make publish
+```
+
+You can then follow the instructions above, setting the `DEV_IMAGE` environment
+variable to your own image location when invoking `deploy.sh`.
+
+Note that testing an image from another location will cause `kustomization.yaml`
+to be updated. Please do not commit these changes.

--- a/test/kubernetes/deploy/deploy.sh
+++ b/test/kubernetes/deploy/deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if ! command -v kustomize >/dev/null 2>&1; then
+    echo 'kustomize not installed'
+    echo 'get it from https://github.com/kubernetes-sigs/kustomize'
+    exit 1
+fi
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo 'kubectl not installed'
+    echo 'install it following the instructions at https://kubernetes.io/docs/tasks/tools/install-kubectl/'
+    exit 1
+fi
+
+if [[ -z "${DIGITALOCEAN_ACCESS_TOKEN:-}" ]]; then
+    echo 'DIGITALOCEAN_ACCESS_TOKEN not defined'
+    exit 1
+fi
+
+current_context=$(kubectl config current-context)
+echo "Deploying a dev version of the CSI driver to context ${current_context}."
+echo "Continue? (yes/no)"
+read -r yesno
+if [[ "${yesno}" != 'yes' ]]; then
+    echo 'Aborted'
+    exit 1
+fi
+
+# Create a secret containing the specified DO API token; this will be used by
+# the dev version of the CSI controller.
+echo "access-token=${DIGITALOCEAN_ACCESS_TOKEN}" | \
+    kubectl -n kube-system create secret generic digitalocean --from-env-file=/dev/stdin
+
+# Configure kustomize to use the specified dev image (default to the one created
+# by `VERSION=dev make publish`).
+: "${DEV_IMAGE:=digitalocean/do-csi-plugin:dev}"
+kustomize edit set image digitalocean/do-csi-plugin:dev="${DEV_IMAGE}"
+# Apply the customization to the dev manifest, and apply it to the cluster.
+kustomize build . --load_restrictor none | kubectl apply -f -
+# Wait for the deployment to complete.
+kubectl -n kube-system wait --timeout=5m --for=condition=Ready pod -l app=csi-do-controller-dev
+kubectl -n kube-system wait --timeout=5m --for=condition=Ready pod -l app=csi-do-node-dev
+kubectl -n kube-system get all

--- a/test/kubernetes/deploy/kustomization.yaml
+++ b/test/kubernetes/deploy/kustomization.yaml
@@ -1,0 +1,91 @@
+# This kustomization allows a dev version of the CSI driver to be installed on a
+# DOKS cluster alongside the preconfigured CSI driver. The dev version uses a
+# different storage class and provisioner name so that volumes can use either
+# one.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+nameSuffix: -dev
+images:
+- name: digitalocean/do-csi-plugin:dev
+  newName: digitalocean/do-csi-plugin
+  newTag: dev
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: csi-do-controller
+    namespace: kube-system
+  spec:
+    serviceName: csi-do-dev
+    template:
+      metadata:
+        labels:
+          app: csi-do-controller-dev
+          role: csi-do-dev
+      spec:
+        serviceAccount: csi-do-controller-sa-dev
+        containers:
+        - name: csi-do-plugin
+          args:
+          - --endpoint=$(CSI_ENDPOINT)
+          - --token=$(DIGITALOCEAN_ACCESS_TOKEN)
+          - --url=$(DIGITALOCEAN_API_URL)
+          - --driver-name=dobs.csi.digitalocean.com-dev
+- |-
+  apiVersion: apps/v1beta2
+  kind: DaemonSet
+  metadata:
+    name: csi-do-node
+    namespace: kube-system
+  spec:
+    selector:
+      matchLabels:
+        app: csi-do-node-dev
+    template:
+      metadata:
+        labels:
+          app: csi-do-node-dev
+          role: csi-do-dev
+      spec:
+        serviceAccount: csi-do-node-sa-dev
+        containers:
+        - name: csi-do-plugin
+          args:
+          - --endpoint=$(CSI_ENDPOINT)
+          - --url=$(DIGITALOCEAN_API_URL)
+          - --driver-name=dobs.csi.digitalocean.com-dev
+        - name: csi-node-driver-registrar
+          env:
+          - name: DRIVER_REG_SOCK_PATH
+            value: /var/lib/kubelet/plugins/dobs.csi.digitalocean.com-dev/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - rm -rf /registration/dobs.csi.digitalocean.com-dev /registration/dobs.csi.digitalocean.com-dev-reg.sock
+        volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/dobs.csi.digitalocean.com-dev
+            type: DirectoryOrCreate
+- |-
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: do-block-storage
+    namespace: kube-system
+    annotations: null
+  provisioner: dobs.csi.digitalocean.com-dev
+- |-
+  apiVersion: snapshot.storage.k8s.io/v1alpha1
+  kind: VolumeSnapshotClass
+  metadata:
+    name: do-block-storage
+    namespace: kube-system
+    annotations: null
+  snapshotter: dobs.csi.digitalocean.com-dev


### PR DESCRIPTION
Currently there's no easy way to test a change to this CSI driver using a DOKS cluster, since DOKS clusters run the CSI controller as a managed component that cannot be modified by users.

This PR introduces a process that can be used to easily test a development version of the CSI driver on a DOKS cluster. We use `kustomize` to modify the provided dev deployment manifest, renaming the storage class, provisioner, and workloads so that the dev version can run alongside the pre-installed version. The integration tests are then run using the dev storage class rather than the production one.

In testing this, I found a problem with the dev manifest (the `DIGITALOCEAN_ACCESS_TOKEN` secret was being provided to the wrong container), so that's fixed here as well. I also noticed that `make test-integration` was using cached results after the first run, which doesn't seem desirable for integration tests; I've used `-count 1` to avoid that.