### PR TITLE
makefile: Avoid using bash-specific features in $(shell) calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,14 @@ build:
 
 .PHONY: push
 push:
-ifeq ($(shell [[ $(BRANCH) != "master" && $(VERSION) != "dev" ]] && echo true ),true)
-	@echo "ERROR: Publishing image with a SEMVER version '$(VERSION)' is only allowed from master"
-else
+ifneq ($(BRANCH),master)
+  ifneq ($(VERSION),dev)
+	$(error "Only the `dev` tag can be published from non-master branches")
+  endif
+endif
 	@echo "==> Publishing $(DOCKER_REPO):$(VERSION)"
 	@docker push $(DOCKER_REPO):$(VERSION)
 	@echo "==> Your image is now available at $(DOCKER_REPO):$(VERSION)"
-endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Previously the `make push` target was using `[[ ]]` conditional expressions, which aren't part of posix sh. This caused warnings like `/bin/sh: 1: [[: not found` when running `make push` on systems where `/bin/sh` is not bash (e.g., Ubuntu, where it's dash).

Avoid shelling out entirely by making better use of make conditionals.