### PR TITLE
Change csi-attacher version to v1.1.1 for CSI release v1.1.2

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.2
+          image: quay.io/k8scsi/csi-attacher:v1.1.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
This was changed inadvertently during our last release because our bump-version Makefile target is too coarse in finding and replacing the presumed CSI release.

Once merged, we should update our repo v1.1.2 tag.

Fixes #195