### PR TITLE
Update CSI v1.1.2 deploy yaml to be on stable API versions.

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml
@@ -117,13 +117,16 @@ provisioner: dobs.csi.digitalocean.com
 ##############################################
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-do-controller
   namespace: kube-system
 spec:
   serviceName: "csi-do"
   replicas: 1
+  selector:
+    matchLabels:
+      app: csi-do-controller
   template:
     metadata:
       labels:
@@ -340,7 +343,7 @@ roleRef:
 ########################################
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-do-node
   namespace: kube-system


### PR DESCRIPTION
Per https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ CSI v1.1.2 failed to apply due to `StatefulSet` and `DaemonSet` needing to be on the latest stable API version in 1.16. `StatefulSet` also needed a `selector` key to apply cleanly.

```
❯ kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml  

csidriver.storage.k8s.io/dobs.csi.digitalocean.com unchanged
customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged
volumesnapshotclass.snapshot.storage.k8s.io/do-block-storage unchanged
storageclass.storage.k8s.io/do-block-storage unchanged
serviceaccount/csi-do-controller-sa unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-provisioner-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-provisioner-binding unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-attacher-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-attacher-binding unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-snapshotter-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-snapshotter-binding unchanged
serviceaccount/csi-do-node-sa unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-node-driver-registrar-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-node-driver-registrar-binding unchanged
unable to recognize "https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml": no matches for kind "StatefulSet" in version "apps/v1beta1"
unable to recognize "https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml": no matches for kind "DaemonSet" in version "apps/v1beta2"
```

Apply with updated API versions per 1.16 deprecation
ref = https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

>   DaemonSet, Deployment, StatefulSet, and ReplicaSet (in the extensions/v1beta1 and apps/v1beta2 API groups)
   Migrate to use the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.

```
❯ kub apply -f ~/devel/csi-digitalocean/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml                                                    
csidriver.storage.k8s.io/dobs.csi.digitalocean.com unchanged
customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured
volumesnapshotclass.snapshot.storage.k8s.io/do-block-storage unchanged
storageclass.storage.k8s.io/do-block-storage unchanged
statefulset.apps/csi-do-controller created
serviceaccount/csi-do-controller-sa unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-provisioner-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-provisioner-binding unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-attacher-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-attacher-binding unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-snapshotter-role configured
clusterrolebinding.rbac.authorization.k8s.io/csi-do-snapshotter-binding unchanged
daemonset.apps/csi-do-node configured
serviceaccount/csi-do-node-sa unchanged
clusterrole.rbac.authorization.k8s.io/csi-do-node-driver-registrar-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/csi-do-node-driver-registrar-binding unchanged
❯ echo $?                                                                                                                                           
0
❯ kub get pods -A                                                                                                                                   
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   cilium-cmd2f                            1/1     Running   0          4h26m
kube-system   cilium-g7vx7                            1/1     Running   0          4h25m
kube-system   cilium-operator-6444788657-9fjrt        1/1     Running   0          4h28m
kube-system   coredns-84c79f5fb4-nwxvj                1/1     Running   0          4h28m
kube-system   coredns-84c79f5fb4-txg5t                1/1     Running   0          4h28m
kube-system   csi-do-controller-0                     4/4     Running   0          21s
kube-system   csi-do-node-b2hw7                       2/2     Running   0          17s
kube-system   csi-do-node-wsb6n                       2/2     Running   0          10s
kube-system   do-node-agent-jlt9k                     1/1     Running   0          4h26m
kube-system   do-node-agent-pw5pv                     1/1     Running   0          4h25m
kube-system   kube-proxy-jtwr7                        1/1     Running   0          4h26m
kube-system   kube-proxy-sndxd                        1/1     Running   0          4h25m
kube-system   kubelet-rubber-stamp-7f966c6779-7csn4   1/1     Running   0          4h28m
```

Verify per CSI docs: 

```
❯ kub apply -f ./pvc.yaml
persistentvolumeclaim/csi-pvc created
kub get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS       REASON   AGE
pvc-e65147aa-6f06-456f-84b3-7103a69686f1   5Gi        RWO            Delete           Bound    default/csi-pvc   do-block-storage            6s
```
