### PR TITLE
Change imagePullPolicy for container spec in the csi manifest

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev.yaml
@@ -1,17 +1,17 @@
-# Copyright 2018 DigitalOcean
-# 
+# Copyright 2019 DigitalOcean
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
+
 # Configuration to deploy release version of the CSI DigitalOcean
 # plugin (https://github.com/digitalocean/csi-digitalocean) compatible with
 # Kubernetes >=v1.14+
@@ -141,7 +141,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "Always"
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -153,7 +153,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "Always"
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -164,7 +164,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -457,4 +457,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: csi-do-node-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io          
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Change imagePullPolicy for all containers except `digitalocean/do-csi-plugin:dev` to `IfNotPresent`.
The images for `csi-provisioner`, `csi-attacher`, `csi-snapshotter` have versioned tags. Any change to them, we bump up the tag. 

@timoreimann - I wasn't sure if I had to change this in the 1.1.2 yaml. Let me know if I have to. Thank you! 