### PR TITLE
Add http health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 ## unreleased
 
 * Implement NodeGetVolumeStats RPC
-  [[GH-197](https://github.com/digitalocean/csi-digitalocean/pull/197)]
+  [[GH-197]](https://github.com/digitalocean/csi-digitalocean/pull/197)
+* Add health check endpoint
+  [[GH-210]](https://github.com/digitalocean/csi-digitalocean/pull/210)
 
 ## v1.1.2 - 2019.09.17
 
 * Improve error messages for incorrectly attached volumes
-  [[GH-176](https://github.com/digitalocean/csi-digitalocean/pull/176)]
-  [[GH-177](https://github.com/digitalocean/csi-digitalocean/pull/177)]
+  [[GH-176]](https://github.com/digitalocean/csi-digitalocean/pull/176)
+  [[GH-177]](https://github.com/digitalocean/csi-digitalocean/pull/177)
 * Allow for custom driver names, to help with upgrades from Kubernetes 1.11
-  [[GH-179](https://github.com/digitalocean/csi-digitalocean/pull/179)]
-  [[GH-182](https://github.com/digitalocean/csi-digitalocean/pull/182)]
+  [[GH-179]](https://github.com/digitalocean/csi-digitalocean/pull/179)
+  [[GH-182]](https://github.com/digitalocean/csi-digitalocean/pull/182)
 
 ## v1.1.1 - 2019.07.02
 

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -32,6 +32,7 @@ func main() {
 		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
 		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach")
 		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver")
+		address    = flag.String("address", driver.DefaultAddress, "Address to serve on")
 		version    = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
@@ -41,7 +42,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName)
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName, *address)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/driver/health.go
+++ b/driver/health.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"golang.org/x/sync/errgroup"
+)
+
+// HealthCheck is the interface that must be implemented to be compatible with
+// `HealthChecker`.
+type HealthCheck interface {
+	Name() string
+	Check(context.Context) error
+}
+
+// HealthChecker helps with writing multi component health checkers.
+type HealthChecker struct {
+	checks []HealthCheck
+}
+
+// NewHealthChecker configures a new health checker with the passed in checks.
+func NewHealthChecker(checks ...HealthCheck) *HealthChecker {
+	return &HealthChecker{
+		checks: checks,
+	}
+}
+
+// Check runs all configured health checks and return an error if any of the
+// checks fail.
+func (c *HealthChecker) Check(ctx context.Context) error {
+	var eg errgroup.Group
+
+	for _, check := range c.checks {
+		eg.Go(func() error {
+			return check.Check(ctx)
+		})
+	}
+
+	return eg.Wait()
+}
+
+var doHealthTimeout = 15 * time.Second
+
+type doHealthChecker struct {
+	account godo.AccountService
+}
+
+func (c *doHealthChecker) Name() string {
+	return "godo"
+}
+
+func (c *doHealthChecker) Check(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, doHealthTimeout)
+	defer cancel()
+	_, _, err := c.account.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("checking do health: %w", err)
+	}
+	return nil
+}

--- a/driver/health_test.go
+++ b/driver/health_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+func TestDoHealthChecker_Name(t *testing.T) {
+	c := doHealthChecker{}
+	if want, got := "godo", c.Name(); want != got {
+		t.Errorf("incorrect name\nwant: %#v \n got: %#v", want, got)
+	}
+}
+
+func TestDoHealthCheker_Check(t *testing.T) {
+	c := doHealthChecker{}
+
+	t.Run("healthy godo", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"account":null}`))
+		}))
+		defer ts.Close()
+
+		client, err := godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.account = client.Account
+
+		err = c.Check(context.Background())
+		if err != nil {
+			t.Errorf("expected no error: %s", err)
+		}
+	})
+
+	t.Run("unhealthy godo", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		client, err := godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.account = client.Account
+
+		err = c.Check(context.Background())
+		if err == nil {
+			t.Error("expected error but got none")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/pflag v1.0.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 	golang.org/x/sys v0.0.0-20190312061237-fead79001313
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	google.golang.org/genproto v0.0.0-20180409222037-51d0944304c3 // indirect

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,6 +111,8 @@ golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
+# golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20190312061237-fead79001313
 golang.org/x/sys/unix
 golang.org/x/sys/windows


### PR DESCRIPTION
We would like to be able to monitor the availability of the CSI driver. This PR adds a health check endpoint for this.

This is a similar change to https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/293, but simpler since we have full control over how we configuring the driver.

Similar future consideration include:
- tying the DO api health to the actual endpoints that we use