### PR TITLE
Fix kustomization.yaml to deploy csi-digitalocean-latest yaml

### DIFF
--- a/test/kubernetes/deploy/kustomization.yaml
+++ b/test/kubernetes/deploy/kustomization.yaml
@@ -5,7 +5,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy/kubernetes/releases/csi-digitalocean-dev.yaml
+- ../../../deploy/kubernetes/releases/csi-digitalocean-latest.yaml
 nameSuffix: -dev
 images:
 - name: digitalocean/do-csi-plugin:dev
@@ -13,13 +13,16 @@ images:
   newTag: dev
 patchesStrategicMerge:
 - |-
-  apiVersion: apps/v1beta1
+  apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     name: csi-do-controller
     namespace: kube-system
   spec:
     serviceName: csi-do-dev
+    selector:
+      matchLabels:
+        app: csi-do-controller-dev
     template:
       metadata:
         labels:
@@ -35,7 +38,7 @@ patchesStrategicMerge:
           - --url=$(DIGITALOCEAN_API_URL)
           - --driver-name=dobs.csi.digitalocean.com-dev
 - |-
-  apiVersion: apps/v1beta2
+  apiVersion: apps/v1
   kind: DaemonSet
   metadata:
     name: csi-do-node


### PR DESCRIPTION
Related: #208 

The kustomization yaml got missed out while renaming the dev manifest to latest.
Also updates the StatefulSet and DaemonSet to `apps/v1` in kustomization.yaml 