### PR TITLE
Allow pushing to a Docker organization other than "digitalocean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,11 @@ build:
 
 .PHONY: push
 push:
-ifneq ($(BRANCH),master)
-  ifneq ($(VERSION),dev)
-	$(error "Only the `dev` tag can be published from non-master branches")
+ifeq ($(DOCKER_REPO),digitalocean/do-csi-plugin)
+  ifneq ($(BRANCH),master)
+    ifneq ($(VERSION),dev)
+	  $(error "Only the `dev` tag can be published from non-master branches")
+    endif
   endif
 endif
 	@echo "==> Publishing $(DOCKER_REPO):$(VERSION)"


### PR DESCRIPTION
This allows to push to a personal organization for testing purposes.

Similar to digitalocean/digitalocean-cloud-controller-manager#197