### PR TITLE
Support prompt override switch in deploy script

### DIFF
--- a/test/kubernetes/deploy/README.md
+++ b/test/kubernetes/deploy/README.md
@@ -20,14 +20,16 @@ To test a development version on a DOKS cluster, do the following:
    from the root of the repository.
 
 3. Run `deploy.sh` from this directory, providing a DO API access token for your
-   account:
+   account (This requires [`kustomize`](https://github.com/kubernetes-sigs/kustomize) and `kubectl`):
+
    ```console
    $ DIGITALOCEAN_ACCESS_TOKEN=<token> ./deploy.sh
    Deploying a dev version of the CSI driver to context do-nyc1-csi-integration-test.
    Continue? (yes/no)
    yes
    ```
-   This requires [`kustomize`](https://github.com/kubernetes-sigs/kustomize) and `kubectl`.
+
+   (You can also pass `-y` or `--yes` as a parameter to `deploy.sh` to skip the prompt.)
 
 4. Run the integration tests from the repository root against the dev storage class:
    ```console

--- a/test/kubernetes/deploy/deploy.sh
+++ b/test/kubernetes/deploy/deploy.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+YES=
+if [[ $# -gt 0 && ( $1 = '-y' || $1 = '--yes' ) ]]; then
+    YES=1
+fi
+readonly YES
+
 if ! command -v kustomize >/dev/null 2>&1; then
     echo 'kustomize not installed'
     echo 'get it from https://github.com/kubernetes-sigs/kustomize'
@@ -20,11 +26,13 @@ fi
 
 current_context=$(kubectl config current-context)
 echo "Deploying a dev version of the CSI driver to context ${current_context}."
-echo "Continue? (yes/no)"
-read -r yesno
-if [[ "${yesno}" != 'yes' ]]; then
-    echo 'Aborted'
-    exit 1
+if [[ -z "${YES}" ]]; then
+    echo "Continue? (yes/no)"
+    read -r yesno
+    if [[ "${yesno}" != 'yes' ]]; then
+        echo 'Aborted'
+        exit 1
+    fi
 fi
 
 # Create a secret containing the specified DO API token; this will be used by


### PR DESCRIPTION
The `-y` or `--yes` switch allows to deploy the dev stack without getting prompted for confirmation. This can be helpful when deploying repeatedly and you know what you are doing.