### PR TITLE
Assume detached state on 404 during ControllerUnpublishVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Assume detached state on 404 during ControllerUnpublishVolume
+  [[GH-221]](https://github.com/digitalocean/csi-digitalocean/pull/221)
 * Implement NodeGetVolumeStats RPC
   [[GH-197]](https://github.com/digitalocean/csi-digitalocean/pull/197)
 * Add health check endpoint

--- a/test/kubernetes/deploy/README.md
+++ b/test/kubernetes/deploy/README.md
@@ -29,10 +29,15 @@ To test a development version on a DOKS cluster, do the following:
    ```
    This requires [`kustomize`](https://github.com/kubernetes-sigs/kustomize) and `kubectl`.
 
-4. Run the integration tests from the repository root against the dev storage class:
+4. Run the integration tests from the repository root specifying a DigitalOcean API token
+   against the dev storage class:
    ```console
-   $ TEST_STORAGE_CLASS=do-block-storage-dev make test-integration
+   $ CSI_DIGITALOCEAN_ACCESS_TOKEN=aa823a5a07d5aa7c TEST_STORAGE_CLASS=do-block-storage-dev make test-integration
    ```
+
+   **Note:** If the `CSI_DIGITALOCEAN_ACCESS_TOKEN` environment variable does not specify
+   a token, the standard `DIGITALOCEAN_ACCESS_TOKEN` environment variable will be tried before
+   returning an error.
 
 ## Alternative Image Locations
 


### PR DESCRIPTION
Previously we would bubble up 404 HTTP response codes during controller unpublish (i.e., volume detachment) events as errors to the invoking external-provisioner, causing the sidecar to go into an infinite retry loop. This change short-circuits the behavior by returning a success message to the caller.

One case where we see the problematic behavior occurring is when users detach volumes directly (i.e., outside of Kubernetes).