### PR TITLE
Reject requests for block access type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Reject requests for block access type
+  [[GH-225]](https://github.com/digitalocean/csi-digitalocean/pull/225)
 * Assume detached state on 404 during ControllerUnpublishVolume
   [[GH-221]](https://github.com/digitalocean/csi-digitalocean/pull/221)
 * Implement NodeGetVolumeStats RPC


### PR DESCRIPTION
The [upstream storage e2e tests expect us to reject requests for unsupported capabilities, to which block access type belongs](https://github.com/kubernetes/kubernetes/blob/v1.16.2/test/e2e/storage/testsuites/volumemode.go#L237-L239). This change fulfills the requirement while also simplifying the existing capability validation logic.

I am going to follow up with a PR that integrates the upstream storage e2e tests into our repo in the not too remote future. For now, I have validated the change by running all upstream e2e tests myself.