### PR TITLE
Address linter violations

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -1084,7 +1084,7 @@ func (d *Driver) tagVolume(parentCtx context.Context, vol *godo.Volume) error {
 	// and then retry tagging the volume resource.
 	ctx, cancel = context.WithTimeout(parentCtx, doAPITimeout)
 	defer cancel()
-	_, _, err = d.tags.Create(parentCtx, &godo.TagCreateRequest{
+	_, _, err = d.tags.Create(ctx, &godo.TagCreateRequest{
 		Name: d.doTag,
 	})
 	if err != nil {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -35,21 +35,6 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-type storageVolumeRoot struct {
-	Volume *godo.Volume `json:"volume"`
-	Links  *godo.Links  `json:"links,omitempty"`
-}
-
-type storageVolumesRoot struct {
-	Volumes []godo.Volume `json:"volumes"`
-	Links   *godo.Links   `json:"links"`
-}
-
-type dropletRoot struct {
-	Droplet *godo.Droplet `json:"droplet"`
-	Links   *godo.Links   `json:"links,omitempty"`
-}
-
 func TestDriverSuite(t *testing.T) {
 	socket := "/tmp/csi.sock"
 	endpoint := "unix://" + socket
@@ -59,8 +44,8 @@ func TestDriverSuite(t *testing.T) {
 
 	nodeID := 987654
 	doTag := "k8s:cluster-id"
-	volumes := make(map[string]*godo.Volume, 0)
-	snapshots := make(map[string]*godo.Snapshot, 0)
+	volumes := make(map[string]*godo.Volume)
+	snapshots := make(map[string]*godo.Snapshot)
 	droplets := map[int]*godo.Droplet{
 		nodeID: {
 			ID: nodeID,

--- a/driver/health_test.go
+++ b/driver/health_test.go
@@ -38,7 +38,10 @@ func TestDoHealthCheker_Check(t *testing.T) {
 	t.Run("healthy godo", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"account":null}`))
+			_, err := w.Write([]byte(`{"account":null}`))
+			if err != nil {
+				t.Error(err)
+			}
 		}))
 		defer ts.Close()
 


### PR DESCRIPTION
- Remove unused structs.
- Use correct context value.
- Simplify `make()` calls.
- Handle `Write()` error.