### PR TITLE
Refactor waitAction

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	metadata "github.com/digitalocean/go-metadata"
@@ -43,7 +44,8 @@ const (
 	DefaultDriverName = "dobs.csi.digitalocean.com"
 	// DefaultAddress is the default address that the csi plugin will serve its
 	// http handler on.
-	DefaultAddress = "127.0.0.1:12302"
+	DefaultAddress           = "127.0.0.1:12302"
+	defaultWaitActionTimeout = 1 * time.Minute
 )
 
 var (
@@ -64,12 +66,13 @@ type Driver struct {
 	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
 	publishInfoVolumeName string
 
-	endpoint     string
-	address      string
-	nodeId       string
-	region       string
-	doTag        string
-	isController bool
+	endpoint          string
+	address           string
+	nodeId            string
+	region            string
+	doTag             string
+	isController      bool
+	waitActionTimeout time.Duration
 
 	srv     *grpc.Server
 	httpSrv http.Server
@@ -146,7 +149,8 @@ func NewDriver(ep, token, url, doTag, driverName, address string) (*Driver, erro
 		log:      log,
 		// for now we're assuming only the controller has a non-empty token. In
 		// the future we should pass an explicit flag to the driver.
-		isController: token != "",
+		isController:      token != "",
+		waitActionTimeout: defaultWaitActionTimeout,
 
 		storage:        doClient.Storage,
 		storageActions: doClient.StorageActions,

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -53,11 +53,12 @@ func TestDriverSuite(t *testing.T) {
 	}
 
 	driver := &Driver{
-		name:     DefaultDriverName,
-		endpoint: endpoint,
-		nodeId:   strconv.Itoa(nodeID),
-		doTag:    doTag,
-		region:   "nyc3",
+		name:              DefaultDriverName,
+		endpoint:          endpoint,
+		nodeId:            strconv.Itoa(nodeID),
+		doTag:             doTag,
+		region:            "nyc3",
+		waitActionTimeout: defaultWaitActionTimeout,
 		mounter: &fakeMounter{
 			mounted: map[string]string{},
 		},


### PR DESCRIPTION
This change refactors `waitAction` to use `wait.PollUntil` from the upstream apimachinery library to hide the underlying polling infrastructure and simplify the implementation.

We also exit the method if the context got cancelled while waiting for a response from the volume API. Previously, we would iterate through the for loop once again and possibly do another unnecessary API interaction if the ticker was ready again by that time.

Finally, we add a unit test (which required making the wait action timeout injectable).

The change passes both our local integration and upstream e2e tests.