### PR TITLE
Prevent kustomize modifications from polluting git

### DIFF
--- a/test/kubernetes/deploy/README.md
+++ b/test/kubernetes/deploy/README.md
@@ -56,6 +56,3 @@ $ DOCKER_REPO=<my-image-repository> VERSION=dev make publish
 
 You can then follow the instructions above, setting the `DEV_IMAGE` environment
 variable to your own image location when invoking `deploy.sh`.
-
-Note that testing an image from another location will cause `kustomization.yaml`
-to be updated. Please do not commit these changes.

--- a/test/kubernetes/deploy/kustomization.yaml
+++ b/test/kubernetes/deploy/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - ../../../deploy/kubernetes/releases/csi-digitalocean-latest.yaml
 nameSuffix: -dev
 images:
-- name: digitalocean/do-csi-plugin:dev
+- name: do-csi-plugin
   newName: digitalocean/do-csi-plugin
   newTag: dev
 patchesStrategicMerge:


### PR DESCRIPTION
We support injecting a different plugin image into the dev/latest manifests. However, this pollutes git my updating the VCS-controlled `kustomization.yaml` file.
This change sets up a bash trap to undo any image changes.

As a drive-by improvement, we also simplify the name of the image to `do-csi-plugin` since it is supposed to reference a generic name and not a specific image version (which is set by `kustomize edit set image`).