### PR TITLE
Increase external-resizer request timeout to 30 seconds

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
@@ -178,6 +178,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--csiTimeout=30s"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
Based on anecdotal data collected and several test runs conducted, we can observe that the default 15 seconds request timeout which the external-resizer sidecar sets is occasionally insufficient to finish a resize operation without one backoff. We bump the timeout to 30 seconds to be on the safe side.