### PR TITLE
Fix image name in kustomization.yaml

### DIFF
--- a/test/kubernetes/deploy/deploy.sh
+++ b/test/kubernetes/deploy/deploy.sh
@@ -47,7 +47,7 @@ kubectl -n kube-system create secret generic digitalocean --from-literal="access
 # Configure kustomize to use the specified dev image (default to the one created
 # by `VERSION=dev make publish`).
 : "${DEV_IMAGE:=$DEFAULT_PLUGIN_IMAGE}"
-kustomize edit set image do-csi-plugin="${DEV_IMAGE}"
+kustomize edit set image digitalocean/do-csi-plugin="${DEV_IMAGE}"
 # Undo any image updates done to kustomization.yaml to prevent git pollution.
 # shellcheck disable=SC2064
 trap "kustomize edit set image do-csi-plugin=$DEFAULT_PLUGIN_IMAGE" EXIT

--- a/test/kubernetes/deploy/kustomization.yaml
+++ b/test/kubernetes/deploy/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - ../../../deploy/kubernetes/releases/csi-digitalocean-latest.yaml
 nameSuffix: -dev
 images:
-- name: do-csi-plugin
+- name: digitalocean/do-csi-plugin
   newName: digitalocean/do-csi-plugin
   newTag: dev
 patchesStrategicMerge:


### PR DESCRIPTION
kustomize needs the full image name (without the tag) to associate the image properly. Otherwise, the kustomize build will not update the image.

This was due to me going overboard with #230.