### PR TITLE
Update sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [[GH-241]](https://github.com/digitalocean/csi-digitalocean/pull/241)
 * Check all snapshots for existence
   [[GH-240]](https://github.com/digitalocean/csi-digitalocean/pull/240)
+* Update sidecars
+  [[GH-238]](https://github.com/digitalocean/csi-digitalocean/pull/238)
 * Support checkLimit for multiple pages
   [[GH-235]](https://github.com/digitalocean/csi-digitalocean/pull/235)
 * Return error when fetching the snapshot fails

--- a/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
@@ -139,7 +139,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          image: quay.io/k8scsi/csi-provisioner:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -151,7 +151,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          image: quay.io/k8scsi/csi-attacher:v2.0.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -275,7 +275,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -284,7 +284,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
- Update csi-provisioner from v1.1.0 to v1.4.0.
- Update csi-attacher from v1.1.1 to v2.0.0.
- provisioner: return content source field in CreatVolumeResponse to   accommodate to behavioral change (see [release nodes](https://github.com/kubernetes-csi/external-provisioner/blob/v1.4.0/CHANGELOG-1.4.md)).
- attacher: add RBAC rules for PATCH operations (see [release nodes](https://github.com/kubernetes-csi/external-attacher/blob/v2.0.0/CHANGELOG-2.0.md)).
- attacher: return OK response when droplet is found missing during   ControllerUnpublishVolume operation to accommodate to behavior change (see [release nodes](https://github.com/kubernetes-csi/external-attacher/blob/v2.0.0/CHANGELOG-2.0.md)).

Note that we did not update external-snapshotter to v1.2.0 since it requires a disruptive update to the alpha CRDs. Suggestion is to move to v2.0.0 straight on Kubernetes 1.17 where snapshotting graduated to beta.

All changes were extensively tested using the upstream e2e tests. (Integration into our CSI repo coming, promised.)