### PR TITLE
Implement graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
   [[GH-241]](https://github.com/digitalocean/csi-digitalocean/pull/241)
 * Check all snapshots for existence
   [[GH-240]](https://github.com/digitalocean/csi-digitalocean/pull/240)
-* Update sidecars
+* Implement graceful shutdown
   [[GH-238]](https://github.com/digitalocean/csi-digitalocean/pull/238)
+* Update sidecars
+  [[GH-236]](https://github.com/digitalocean/csi-digitalocean/pull/236)
 * Support checkLimit for multiple pages
   [[GH-235]](https://github.com/digitalocean/csi-digitalocean/pull/235)
 * Return error when fetching the snapshot fails

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -81,9 +81,16 @@ func TestDriverSuite(t *testing.T) {
 		account: &fakeAccountDriver{},
 		tags:    &fakeTagsDriver{},
 	}
-	defer driver.Stop()
 
-	go driver.Run()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err := driver.Run(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
 
 	cfg := &sanity.Config{
 		TargetPath:  os.TempDir() + "/csi-target",


### PR DESCRIPTION
This change implements graceful shutdown so that a proper driver termination leads to an exit code of zero.

Specifically, we handle signals, and let the HTTP and gRPC servers finish requests gracefully.

We also remove the `Stop()` function in favor a context-based approach.