### PR TITLE
Use vendored dependencies when compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ bump-version:
 .PHONY: compile
 compile:
 	@echo "==> Building the project"
-	@docker run --rm -it -e GOOS=${OS} -e GOARCH=amd64 -v ${PWD}/:/app -w /app golang:1.13-alpine sh -c 'apk add git && go build -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG}'
+	@docker run --rm -it -e GOOS=${OS} -e GOARCH=amd64 -v ${PWD}/:/app -w /app golang:1.13-alpine sh -c 'apk add git && go build -mod=vendor -o cmd/do-csi-plugin/${NAME} -ldflags "$(LDFLAGS)" ${PKG}'
 
 .PHONY: check-unused
 check-unused: vendor


### PR DESCRIPTION
When compiling inside the build container with Go 1.13+, we have no Go modules cache available so all dependencies are being pulled.

Since we use vendoring, we can instruct the Go build tools to enable vendoring mode to speed up the containerized build.