### PR TITLE
Use WARN log level for non-critical failures to get an action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Use WARN log level for non-critical failures to get an action
+  [[GH-241]](https://github.com/digitalocean/csi-digitalocean/pull/241)
 * Reject requests for block access type
   [[GH-225]](https://github.com/digitalocean/csi-digitalocean/pull/225)
 * Assume detached state on 404 during ControllerUnpublishVolume

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -966,7 +966,7 @@ func (d *Driver) waitAction(ctx context.Context, volumeId string, actionId int) 
 		if err != nil {
 			ctxCanceled := ctx.Err() != nil
 			if !ctxCanceled {
-				ll.WithError(err).Info("getting action for volume")
+				ll.WithError(err).Warn("getting action for volume")
 				return false, nil
 			}
 


### PR DESCRIPTION
Action failures are a common source and good indicator for certain CSI-related issues. Logging them at the WARN level makes it easier to identify problems when analyzing logs.