### PR TITLE
Check volume exists during NodeUnpublishVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Check volume exists during NodeUnpublishVolume
+  [[GH-243]](https://github.com/digitalocean/csi-digitalocean/pull/243)
 * Use WARN log level for non-critical failures to get an action
   [[GH-241]](https://github.com/digitalocean/csi-digitalocean/pull/241)
 * Return error when fetching the snapshot fails

--- a/driver/node.go
+++ b/driver/node.go
@@ -25,6 +25,7 @@ limitations under the License.
 package driver
 
 import (
+	"net/http"
 	"context"
 	"path/filepath"
 
@@ -265,6 +266,16 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 		"method":      "node_unpublish_volume",
 	})
 	ll.Info("node unpublish volume called")
+
+	// TODO(treimann): Update csi-sanity once
+	// https://github.com/kubernetes-csi/csi-test/pull/242 has been released.
+	_, resp, err := d.storage.GetVolume(ctx, req.VolumeId)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get volume %q: %s", req.VolumeId, err)
+	}
 
 	mounted, err := d.mounter.IsMounted(req.TargetPath)
 	if err != nil {


### PR DESCRIPTION
The[ CSI spec mandates that we return NOT_FOUND if the volume isn't found](https://github.com/container-storage-interface/spec/blob/4731db0e0bc53238b93850f43ab05d9355df0fd9/spec.md#nodeunpublishvolume-errors). Otherwise, the calling sidecar will go into an endless retry loop.

A test for this case should go into github.com/kubernetes-csi/csi-test but was yet missing. A [PR](https://github.com/kubernetes-csi/csi-test/pull/242) has been submitted and this change has been tested against it. As soon as upstream approves, we can follow up with another PR to incorporate an updated csi-sanity package.

Refs #242 where the issue was discovered.