### PR TITLE
Revert "Check volume exists during NodeUnpublishVolume"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 * Fix and improve logging
   [[GH-244]](https://github.com/digitalocean/csi-digitalocean/pull/244)
-* Check volume exists during NodeUnpublishVolume
-  [[GH-243]](https://github.com/digitalocean/csi-digitalocean/pull/243)
 * Use WARN log level for non-critical failures to get an action
   [[GH-241]](https://github.com/digitalocean/csi-digitalocean/pull/241)
 * Check all snapshots for existence

--- a/driver/node.go
+++ b/driver/node.go
@@ -26,7 +26,6 @@ package driver
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -273,16 +272,6 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 		"method":      "node_unpublish_volume",
 	})
 	log.Info("node unpublish volume called")
-
-	// TODO(treimann): Update csi-sanity once
-	// https://github.com/kubernetes-csi/csi-test/pull/242 has been released.
-	_, resp, err := d.storage.GetVolume(ctx, req.VolumeId)
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return nil, status.Errorf(codes.NotFound, "volume %q not found", req.VolumeId)
-		}
-		return nil, status.Errorf(codes.Internal, "failed to get volume %q: %s", req.VolumeId, err)
-	}
 
 	mounted, err := d.mounter.IsMounted(req.TargetPath)
 	if err != nil {


### PR DESCRIPTION
After [consulting with SIG Storage](https://kubernetes.slack.com/archives/C8EJ01Z46/p1576538436024100), it turned out that the kind of volume existence check implemented by the reverted commit is to be a node-local operation and not something we should reach out to the API for.
Additonally, it primarily applies to volume types that need to connect to the device locally, such as local disks. This is not the case for our type of storage.

This reverts commit d009d46792da41948a6a3ebf27b8ce52988fce00.