### PR TITLE
Remove/generalize references to latest plugin version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ bump-version:
 	@cp deploy/kubernetes/releases/csi-digitalocean-latest.yaml deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
 	@sed -i'' -e 's#digitalocean/do-csi-plugin:dev#digitalocean/do-csi-plugin:${NEW_VERSION}#g' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
 	@sed -i'' -e '/^# This file is only for development use/d' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
-	@sed -i'' -e 's/${VERSION}/${NEW_VERSION}/g' README.md
 	$(eval NEW_DATE = $(shell date +%Y.%m.%d))
 	@sed -i'' -e 's/## unreleased/## ${NEW_VERSION} - ${NEW_DATE}/g' CHANGELOG.md
 	@ echo '## unreleased\n' | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Cloud Foundry. Feel free to test it on other CO's and give us a feedback.
 ## Releases
 
 The DigitalOcean CSI plugin follows [semantic versioning](https://semver.org/).
-The current version is: **`v1.1.2`**. The plugin will be bumped following the
-rules below:
+The version will be bumped following the rules below:
 
 * Bug fixes will be released as a `PATCH` update.
 * New features (such as CSI spec bumps with no breaking changes) will be released as a `MINOR` update.
@@ -162,17 +161,19 @@ digitalocean          Opaque                                1         18h
 #### 2. Deploy the CSI plugin and sidecars:
 
 Before you continue, be sure to checkout to a [tagged
-release](https://github.com/digitalocean/csi-digitalocean/releases). Always use the [latest stable version](https://github.com/digitalocean/csi-digitalocean/releases/latest) 
-For example, to use the latest stable version (`v1.1.2`) you can execute the following command:
+release](https://github.com/digitalocean/csi-digitalocean/releases). Always use the [latest version](https://github.com/digitalocean/csi-digitalocean/releases) compatible with your Kubernetes release (see the [compatibility information](#kubernetes-compatibility)).
 
-```
-$ kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-v1.1.2.yaml
+The [releases directory](deploy/kubernetes/releases) directory holds manifests for all plugin releases. You can deploy a specific version by executing the command
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z.yaml
 ```
 
-This file will be always updated to point to the latest stable release. If you
-see any issues during the installation, this could be because the newly created
-CRD's haven't been established yet. If you call `kubectl apply -f` again on the
-same file, the missing resources will be applied again
+where `vX.Y.Z` is the plugin target version.
+
+If you see any issues during the installation, this could be because the newly
+created CRDs haven't been established yet. If you call `kubectl apply -f` again
+on the same file, the missing resources will be applied again.
 
 
 #### 3. Test and verify:
@@ -289,10 +290,10 @@ Dependencies are managed via [Go modules](https://github.com/golang/go/wiki/Modu
 
 ### Release a new version
 
-To release a new version bump first the version:
+To release a new version `vX.Y.Z`, first bump the version:
 
 ```
-$ make NEW_VERSION=v1.1.2 bump-version
+$ make NEW_VERSION=vX.Y.Z bump-version
 ```
 
 Make sure everything looks good. Create a new branch with all changes:
@@ -305,15 +306,15 @@ $ git push origin
 
 After it's merged to master, [create a new Github
 release](https://github.com/digitalocean/csi-digitalocean/releases/new) from
-master with the version `v1.1.2` and then publish a new docker build:
+master with the version `vX.Y.Z` and then publish a new docker build:
 
 ```
 $ git checkout master
 $ make publish
 ```
 
-This will create a binary with version `v1.1.2` and docker image pushed to
-`digitalocean/do-csi-plugin:v1.1.2`
+This will create a binary with version `vX.Y.Z` and docker image pushed to
+`digitalocean/do-csi-plugin:vX.Y.Z`.
 
 ## Contributing
 


### PR DESCRIPTION
Pointing at and keeping track of the latest plugin version in the README file (e.g., `v1.1.2` at the time of this PR) has been the source of two kinds of problems:

1. The README file is being updated during development, with changes possibly relating to upcoming features. Mentioning the latest release in the same file has led to the wrong assumption with some users that references to yet unreleased features are already available with the latest release. This is because we conflate changes pertaining to master only with references to tags / stable identifiers.
2. Bumping/replacing the version in a purely text-based manner is error-prone and [has already caused issues in our manifest files](https://github.com/digitalocean/csi-digitalocean/pull/198) where we apply similar patterns.

Pointing at the latest release in the README seems unnecessary since that is what the Github Releases page is for; additionally, version-specific documentation should be retrieved via tag-based links. Consequently, this change removes / generalizes the references to improve clarity and simplify house-keeping chores.

Once agreed and approved upon, I am going to submit a similar change for the older release branches (though I plan to mention the version specifier (e.g., 0.4.x) there).