### PR TITLE
Update provisioner and snapshotter sidecars for release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## unreleased
 
+* Update csi-provisioner and csi-snapshotter sidecars
+  [[GH-256]](https://github.com/digitalocean/csi-digitalocean/pull/256)]
 * Backport several fixes and improvements from master
   * test: Add kustomization for deploying a dev version
   * Assume detached state on 404 during ControllerUnpublishVolume
   * Improve and fix logging
   * Improve Makefile
-* [[GH-254]](https://github.com/digitalocean/csi-digitalocean/pull/254)]
+  [[GH-254]](https://github.com/digitalocean/csi-digitalocean/pull/254)]
 * Add health check endpoint
   [[GH-213]](https://github.com/digitalocean/csi-digitalocean/pull/213)]
 

--- a/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
@@ -167,7 +167,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: quay.io/k8scsi/csi-provisioner:v1.0.2
           args:
             - "--provisioner=dobs.csi.digitalocean.com"
             - "--csi-address=$(ADDRESS)"
@@ -192,7 +192,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.0.1
+          image: quay.io/k8scsi/csi-snapshotter:v1.0.2
           args:
             - "--connection-timeout=15s"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
- Update csi-provisioner from v1.0.1 to v1.0.2.
- Update csi-snapshotter from v1.0.1 to v1.0.2.