### PR TITLE
Update csi-provisioner to v0.4.3 in 0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## unreleased
 
+* Update csi-provisioner to v0.4.3
+  [[GH-257]](https://github.com/digitalocean/csi-digitalocean/pull/257)]
 * Backport several fixes and improvements from master
   * test: Add kustomization for deploying a dev version
   * Assume detached state on 404 during ControllerUnpublishVolume
   * Improve and fix logging
   * Improve Makefile
-* [[GH-255]](https://github.com/digitalocean/csi-digitalocean/pull/255)]
+  [[GH-255]](https://github.com/digitalocean/csi-digitalocean/pull/255)]
 * Add health check endpoint
   [[GH-214]](https://github.com/digitalocean/csi-digitalocean/pull/214)
 

--- a/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
@@ -214,7 +214,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.4.2
+          image: quay.io/k8scsi/csi-provisioner:v0.4.3
           args:
             - "--provisioner=dobs.csi.digitalocean.com"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
This is to address the latest CVE.