### PR TITLE
Enable block volumes in upstream e2e tests

### DIFF
--- a/test/e2e/testdrivers/1.14.yaml
+++ b/test/e2e/testdrivers/1.14.yaml
@@ -7,6 +7,7 @@ DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   Capabilities:
     persistence: true
+    block: true
     fsGroup: true
     exec: true
     dataSource: true

--- a/test/e2e/testdrivers/1.15.yaml
+++ b/test/e2e/testdrivers/1.15.yaml
@@ -7,6 +7,7 @@ DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   Capabilities:
     persistence: true
+    block: true
     fsGroup: true
     exec: true
     dataSource: true

--- a/test/e2e/testdrivers/1.16.yaml
+++ b/test/e2e/testdrivers/1.16.yaml
@@ -6,6 +6,7 @@ DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   Capabilities:
     persistence: true
+    block: true
     fsGroup: true
     exec: true
     snapshotDataSource: true


### PR DESCRIPTION
With support for raw block volumes available, we should enable the corresponding upstream end-to-end tests.