### PR TITLE
Support skipping parallel / sequential tests

### DIFF
--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -34,9 +34,19 @@ focus=
 if [[ "${FOCUS:-}" ]]; then
   focus=".*${focus}"
 fi
-echo 'Running parallel tests'
-# Set node count explicitly since node detection does not work properly inside a
-# container.
-ginkgo -v -p -nodes 10 -focus="External.Storage${focus}" -skip='\[Feature:|\[Disruptive\]|\[Serial\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
-echo 'Running sequential tests'
-ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+
+if [[ "${SKIP_PARALLEL_TESTS:-}" ]]; then
+  echo 'Skipping parallel tests'
+else
+  echo 'Running parallel tests'
+  # Set node count explicitly since node detection does not work properly inside a
+  # container.
+  ginkgo -v -p -nodes 10 -focus="External.Storage${focus}" -skip='\[Feature:|\[Disruptive\]|\[Serial\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+fi
+
+if [[ "${SKIP_SEQUENTIAL_TESTS:-}" ]]; then
+  echo 'Skipping sequential tests'
+else
+  echo 'Running sequential tests'
+  ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+fi


### PR DESCRIPTION
Using ginkgo test focuses alone can still cause tests to run fairly long since the skip conditions are determined at run time (sometimes by reaching out to the driver via gRPC).

We improve the situation by introducing two flags that allow to skip all of the parallel or sequential tests, respectively.