### PR TITLE
Fix Travis configuration to call right Makefile target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 
-matrix:
-  include:
-  - go: "1.13"
-    script: go test -v -mod=vendor ./...
-  - go: tip
-    script: go test -v -mod=vendor ./...
+go:
+  - "1.13"
+  - tip
+
+script:
+  - make all
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Our "all" target is supposed to be suitable for CI, but we did not use it.