### PR TITLE
Add snapshotter v1.2.2 updates to v1.2.0 manifest

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-v1.2.0.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-v1.2.0.yaml
@@ -57,6 +57,8 @@ spec:
     plural: volumesnapshotclasses
   scope: Cluster
   version: v1alpha1
+  subresources:
+    status: {}
 
 ---
 
@@ -85,6 +87,8 @@ spec:
     plural: volumesnapshots
   scope: Namespaced
   version: v1alpha1
+  subresources:
+    status: {}
 
 ---
 
@@ -162,7 +166,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -311,7 +315,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -330,9 +334,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
The manifest for CSI driver v1.2.0 was missing the latest snapshotter updates (#266). This change adds them from [the `-latest` manifest](https://github.com/digitalocean/csi-digitalocean/blob/6288d808754ad8c4e409a8346e43ea3973b64950/deploy/kubernetes/releases/csi-digitalocean-latest.yaml).

Note that all tests were done against `-latest`, so this should not have an impact on correctness.