### PR TITLE
e2e tests: keep cluster and node pool names at valid lengths

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,6 +111,9 @@ jobs:
           NAME_SUFFIX="${BRANCH}"
           TAG="${BRANCH}"
           if [[ $BRANCH != "" ]]; then
+            # Hash name suffix which goes into the cluster name to ensure we do
+            # not exceed any name constraints.
+            NAME_SUFFIX=$(echo -n ${BRANCH} | sha256sum | cut -c1-7)
             RUNNER_IMAGE_TAG_PREFIX=${BRANCH}-
           else
             NAME_SUFFIX=master

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -220,7 +220,7 @@ func TestE2E(t *testing.T) {
 					t.Fatalf("failed to create DigitalOcean API client: %s", err)
 				}
 
-				kubeconfigData, cleanup, err := createCluster(ctx, client, p.nameSuffix, kubeVer)
+				kubeconfigData, cleanup, err := createCluster(ctx, client, p.nameSuffix, majorMinorVer, kubeVer)
 				// Ignore error in order to clean up any partial cluster setups
 				// as long as we received a cleanup function and do not intend
 				// to retain the cluster.
@@ -298,8 +298,8 @@ func createDOClient(ctx context.Context, token string) (client *godo.Client, err
 	return doClient, nil
 }
 
-func createCluster(ctx context.Context, client *godo.Client, nameSuffix, kubeVersion string) (*godo.KubernetesClusterConfig, func(ctx context.Context) error, error) {
-	kubeVerSanitized := strings.ReplaceAll(kubeVersion, ".", "-")
+func createCluster(ctx context.Context, client *godo.Client, nameSuffix, kubeMajorMinorVersion, versionSlug string) (*godo.KubernetesClusterConfig, func(ctx context.Context) error, error) {
+	kubeVerSanitized := strings.ReplaceAll(kubeMajorMinorVersion, ".", "-")
 	clusterName := fmt.Sprintf("csi-e2e-%s-test-%s", kubeVerSanitized, nameSuffix)
 	versionTag := fmt.Sprintf("version:%s", kubeVerSanitized)
 
@@ -338,7 +338,7 @@ func createCluster(ctx context.Context, client *godo.Client, nameSuffix, kubeVer
 	cluster, resp, err := client.Kubernetes.Create(ctx, &godo.KubernetesClusterCreateRequest{
 		Name:        clusterName,
 		RegionSlug:  "fra1",
-		VersionSlug: kubeVersion,
+		VersionSlug: versionSlug,
 		Tags:        []string{"csi-e2e-test", versionTag},
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{
 			&godo.KubernetesNodePoolCreateRequest{


### PR DESCRIPTION
Our existing cluster and node pool naming schema may include components of indeterministic length, such as the branch name in CI. However, DOKS rejects cluster and node pool names that are too long to ensure conformity with DNS naming rules imposed by Kubernetes.

This change makes sure that cluster and node pool names stay within valid bounds. Specifically, we limit the cluster name by including the shorter Kubernetes major/minor version only. Additionally, we
name-suffix cluster names with the hash of the branch name instead of the branch itself during CI. (We do not do this in general since interactive users likely want readable names and should know what they are doing.)

Based on #278 since we leverage the major/minor version extraction which that PR introduced.