### PR TITLE
Improve debug HTTP server usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* Improve debug HTTP server usage
+  [[GH-281]](https://github.com/digitalocean/csi-digitalocean/pull/281)
+
 ## v1.2.0 - 2020.01.15
 
 * Update csi-snapshotter to v1.2.2

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -35,7 +35,7 @@ func main() {
 		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
 		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach")
 		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver")
-		address    = flag.String("address", driver.DefaultAddress, "Address to serve on")
+		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on")
 		version    = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName, *address)
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName, *debugAddr)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
- Rename the `-address` parameter to `-debug-addr`.
- Only start the HTTP server on the Controller service: the Node service does not have a token configured and thus would never be able to respond successfully to a request.
- Only start the debug server if `-debug-addr` is given, ensuring that existing users won't be surprised by the new functionality. This also allows us to test a dev version of the CSI plugin on a cluster where  the port might already be used.
- Remove explicit HTTP listener which is encapsulated by HTTP server.
- Bound graceful HTTP server shutdown by 10 seconds.