### PR TITLE
delete PR images from Dockerhub after merge

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -1,0 +1,20 @@
+name: delete-pr-images
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  delete_tags:
+    name: Delete PR images from Dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: dockerhub task
+        env:
+          BRANCH: ${{ github.head_ref }}
+          DOCKER_USER: ${{ secrets.DockerHubUser }}
+          DOCKER_PASS: ${{ secrets.DockerHubToken }}
+        run: |
+          BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
+          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.14" "${BRANCH}-tests-1.15" "${BRANCH}-tests-1.16" "${BRANCH}-builder" "${BRANCH}-builder-pre-1.16")
+          for i in ${images[*]}; do curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
+          curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/


### PR DESCRIPTION
When a PR is either closed or merged, this job will run to delete the associated images from Dockerhub repos: https://hub.docker.com/r/digitalocean/do-csi-plugin-dev and https://hub.docker.com/r/digitalocean/k8s-e2e-test-runner. 

If the image is not available, then the API requests succeeds with 200 but response just has `Not found`. We ignore and continue in such cases. 