### PR TITLE
Return minimum disk size field from snapshot response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Return minimum disk size field from snapshot response
+  [[GH-298]](https://github.com/digitalocean/csi-digitalocean/pull/298)
 * Improve debug HTTP server usage
   [[GH-281]](https://github.com/digitalocean/csi-digitalocean/pull/281)
 

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -1108,7 +1108,7 @@ func toCSISnapshot(snap *godo.Snapshot) (*csi.Snapshot, error) {
 	return &csi.Snapshot{
 		SnapshotId:     snap.ID,
 		SourceVolumeId: snap.ResourceID,
-		SizeBytes:      int64(snap.SizeGigaBytes) * giB,
+		SizeBytes:      int64(snap.MinDiskSize) * giB,
 		CreationTime:   tstamp,
 		ReadyToUse:     true,
 	}, nil


### PR DESCRIPTION
We incorrectly returned the billable size of the snapshot instead of the minimum size. The latter represents the usable size the volume was created with and serves as a hint to Kubernetes for how big volumes created off of snapshots should be.

Refs #292