### PR TITLE
Support filtering snapshots by IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Support filtering snapshots by ID
+  [[GH-299]](https://github.com/digitalocean/csi-digitalocean/pull/299)
 * Return minimum disk size field from snapshot response
   [[GH-298]](https://github.com/digitalocean/csi-digitalocean/pull/298)
 * Improve debug HTTP server usage


### PR DESCRIPTION
Our implementation of `ListSnapshots` currently returns all snapshots. The request parameter also provides fields to filter by snapshot ID and source volume ID, which we have been ignoring so far.

Based on [discussions with SIG Storage](https://kubernetes.slack.com/archives/C8EJ01Z46/p1587038433091900), it became clear that CSI
drivers are expected to process present IDs in the `ListSnapshots` call appropriately. While the spec marks them as OPTIONAL, it turned out that the optionality refers to the CO, not the SP. (A request for
clarification [has been filed](https://github.com/container-storage-interface/spec/issues/426).) As soon as any of IDs are provided, drivers are expected to take them into account.  In fact, csi-snapshotter always passes a snapshot ID in and only ever takes the first snapshot item from the list of snapshots returned, which means that our current implementation is buggy for cases where the account
holds more than one snapshot (at least on Kubernetes; other COs could potentially behave differently).

This change fixes the issue by retrieving the snapshot by direct lookup if a snapshot ID is given.

If a source volume ID is given, we do additional filtering by only returning the snapshots that were sourced by the same volume.

The existing csi-sanity tests did not catch this bug. A [PR to that project](https://github.com/kubernetes-csi/csi-test/pull/259) was submitted to close the gap. I tested it locally and verified that the test now works. Once it is merged, we should upgrade our version of the test package.