### PR TITLE
Fix linter complaints

### DIFF
--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -248,9 +248,8 @@ func (m *mounter) IsFormatted(source string) (bool, error) {
 		exitCode = ws.ExitStatus()
 		if exitCode == blkidExitStatusNoIdentifiers {
 			return false, nil
-		} else {
-			return false, fmt.Errorf("checking formatting failed: %v cmd: %q, args: %q", err, blkidCmd, blkidArgs)
 		}
+		return false, fmt.Errorf("checking formatting failed: %v cmd: %q, args: %q", err, blkidCmd, blkidArgs)
 	}
 
 	return true, nil


### PR DESCRIPTION
- Replace single-case switch statement by type assertion.
- Capitalize "ID" variable name suffix.
- Drop obsolete else branch following return statement.