### PR TITLE
Run 1.17 upstream E2E tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,17 @@ jobs:
       - name: Log into container registry
         run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin
 
+      # Github Actions provides a limited amount of disk space only that we
+      # exceed during the Docker build (https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources).
+      # Free up as much disk space as possible.
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
       - name: build and push runner image
         env:
           # ${{ github.head_ref }} is empty for non-pull requests, which is

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,12 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.16', '1.15', '1.14']
+        testdriver: ['']
+        kube-release: ['1.17.5-do.0', '1.16', '1.15', '1.14']
+        include:
+          - kube-release: '1.17.5-do.0'
+            testdriver: 1.16.snapshot-only
+            runner-kube-version: 1.16
 
     steps:
       - name: checkout
@@ -118,6 +123,8 @@ jobs:
           # The upstream end-to-end tests are quite demanding in terms of API
           # request volume, and we run them concurrently.
           NUM_GINKGO_NODES: "8"
+          TESTDRIVER: ${{ matrix.testdriver }}
+          RUNNER_KUBE_VERSION: ${{ matrix.runner-kube-version }}
         run: |
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           NAME_SUFFIX="${BRANCH}"
@@ -131,7 +138,14 @@ jobs:
             NAME_SUFFIX=master
             TAG=latest
           fi
-          TIMEOUT=60m make test-e2e E2E_ARGS="-ginkgo-nodes ${NUM_GINKGO_NODES} -driver-image ${DOCKER_ORG}/do-csi-plugin-dev:${TAG} -runner-image ${DOCKER_ORG}/k8s-e2e-test-runner:${RUNNER_IMAGE_TAG_PREFIX}latest -name-suffix ${NAME_SUFFIX} ${{ matrix.kube-release }}"
+
+          if [[ $TESTDRIVER ]]; then
+            NAME_SUFFIX="${NAME_SUFFIX}-snapshot-only"
+            TESTDRIVER="-testdriver $TESTDRIVER"
+            RUNNER_KUBE_VERSION="-runner-kube-version $RUNNER_KUBE_VERSION"
+          fi
+
+          TIMEOUT=60m make test-e2e E2E_ARGS="-ginkgo-nodes ${NUM_GINKGO_NODES} -driver-image ${DOCKER_ORG}/do-csi-plugin-dev:${TAG} -runner-image ${DOCKER_ORG}/k8s-e2e-test-runner:${RUNNER_IMAGE_TAG_PREFIX}latest ${RUNNER_KUBE_VERSION} ${TESTDRIVER} -name-suffix ${NAME_SUFFIX} ${{ matrix.kube-release }}"
 
   tag-new-master-image:
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,8 @@ runner-build:
 	@docker pull $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):builder || true
+	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 || true
+	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.17 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.16 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 || true
@@ -161,12 +163,24 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder -f test/e2e/Dockerfile test/e2e
 
+	@echo "building target tests-1.17"
+	@docker build --target tests-1.17 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder-pre-1.16 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
+		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 -f test/e2e/Dockerfile test/e2e
+
 	@echo "building target tests-1.16"
 	@docker build --target tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder-pre-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 -f test/e2e/Dockerfile test/e2e
@@ -177,6 +191,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 \
@@ -189,6 +205,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 \
@@ -203,6 +221,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 \
@@ -219,6 +239,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 \
@@ -237,6 +259,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder-pre-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.16 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15 \
@@ -254,6 +278,7 @@ runner-build:
 runner-push: runner-build
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder-pre-1.16
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder
+	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.16
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.15
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.14

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -27,6 +27,16 @@ RUN apt-get update && \
 RUN mkdir -p /go/src/k8s.io
 WORKDIR /go/src/k8s.io
 
+### Kubernetes 1.17
+FROM builder AS tests-1.17
+ARG SHA_1_17=0634ed8
+
+RUN git clone --depth 1 --branch do-doks-1.17 https://github.com/digitalocean/kubernetes.git
+RUN cd kubernetes && \
+    git checkout ${SHA_1_17} && \
+    make WHAT=test/e2e/e2e.test && \
+    cp _output/bin/e2e.test /e2e.1.17.test
+
 ### Kubernetes 1.16
 FROM builder AS tests-1.16
 ARG SHA_1_16=c9bc6a0
@@ -67,7 +77,7 @@ ARG DOCTL_VERSION=1.36.0
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.
-ARG KUBECTL_VERSION=1.16.3
+ARG KUBECTL_VERSION=1.17.5
 
 RUN curl --fail --location --output /tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini
 RUN chmod u+x /tini
@@ -87,6 +97,7 @@ FROM bitnami/minideb:buster AS runtime
 # Certificates needed to trust the CA for any HTTPS connections to the DO API.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends ca-certificates
+COPY --from=tests-1.17 /e2e.1.17.test /
 COPY --from=tests-1.16 /e2e.1.16.test /
 COPY --from=tests-1.15 /e2e.1.15.test /
 COPY --from=tests-1.14 /e2e.1.14.test /

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -59,16 +59,30 @@ Command-line arguments are passed as-in to the test tool. Run `e2e.sh -h` for us
 ### Run the end-to-end tests
 
 1. If necessary, update the test runner image (see below for instructions)
-2. If necessary, add or update the testdriver file definitions (see the [related section above](#testdrivers) for details)
-3. Execute `e2e.sh`, passing in parameters as needed
+1. If necessary, add or update the testdriver file definitions (see the [related section above](#testdrivers) for details)
+1. Execute `e2e.sh`, passing in parameters as needed
 
-### Update the test runner image
+### Update an existing test runner image
 
 1. Make and push any necessary updates to our Kubernetes fork
-2. If the fork was updated: Update the `SHA_*` build argument(s) in the Dockerfile to point to the new commit hash(es)
-3. Run `handle-image.sh build`
-4. Run `handle-image.sh push`
+1. If the fork was updated: Update the `SHA_*` build argument(s) in the runner image Dockerfile to point to the new commit hash(es)
+1. Add the build argument
 
-For testing purposes, you may also overwrite a commit hash on-the-fly by defining the corresponding environment variable(s) `SHA_*`, e.g.: `SHA_1_16=deadbeef ./handle-image.sh build`.
+### Add support for a new Kubernetes release
+
+1. Make and push any necessary updates to our Kubernetes fork
+1. Add a new Kubernetes version-specific block to the runner image Dockerfile; make sure to update the `SHA_*` variable as well
+1. Update the kubectl version in the test runner Dockerfile
+1. Update the Makefile `runner-build` and `runner-push` targets
+1. Extend the `SHA_*` variables in the `handle-images.sh` script
+1. Add a new testdriver YAML configuration file
+1. Extend the list of supported Kubernetes releases in `e2e_test.go`
+1. Extend the list of tested Kubernetes releases in `.github/workflows/test.yaml`
+
+### handle-image.sh
+
+The `handle-image.sh` script can be used to either `build` or `push` a runner image. It should only be needed for testing images hosted on a personal Docker Hub account because the CI manages the canonical images under the `digitalocean` organization.
+
+You may also overwrite a commit hash on-the-fly by defining the corresponding environment variable(s) `SHA_*`, e.g.: `SHA_1_16=deadbeef ./handle-image.sh build`.
 
 The image to be built may be overwritten by defining the `IMAGE` variable, e.g.: `IMAGE=timoreimann/k8s-e2e-test-runner ./handle-image.sh build`.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,7 +54,7 @@ var (
 	errTokenMissing = errors.New("token must be specified in DIGITALOCEAN_ACCESS_TOKEN environment variable")
 
 	// De-facto global variables that require initialization at runtime.
-	supportedKubernetesVersions     = []string{"1.16", "1.15", "1.14"}
+	supportedKubernetesVersions     = []string{"1.17", "1.16", "1.15", "1.14"}
 	sourceFileDir                   string
 	testdriverDirectoryAbsolutePath string
 	deployScriptPath                string

--- a/test/e2e/handle-image.sh
+++ b/test/e2e/handle-image.sh
@@ -34,7 +34,7 @@ readonly OPERATION="$1"
 
 case "${OPERATION}" in
   build)
-    docker build -t "${IMAGE}" --build-arg SHA_1_16 --build-arg SHA_1_15 --build-arg SHA_1_14 -f "${SCRIPT_DIR}/Dockerfile" .
+    docker build -t "${IMAGE}" --build-arg SHA_1_17 --build-arg SHA_1_16 --build-arg SHA_1_15 --build-arg SHA_1_14 -f "${SCRIPT_DIR}/Dockerfile" .
     ;;
   
   push)

--- a/test/e2e/testdrivers/1.16.snapshot-only.yaml
+++ b/test/e2e/testdrivers/1.16.snapshot-only.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: dobs.csi.digitalocean.com-dev
+  Capabilities:
+    persistence: false
+    block: false
+    fsGroup: false
+    exec: false
+    snapshotDataSource: true
+    multipods: false
+    controllerExpansion: false
+    nodeExpansion: false
+    volumeLimits: false
+    singleNodeVolume: false
+  SupportedFsType:
+    ext4:

--- a/test/e2e/testdrivers/1.17.yaml
+++ b/test/e2e/testdrivers/1.17.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: dobs.csi.digitalocean.com-dev
+  SupportedSizeRange:
+    Max: 100Gi
+    Min: 1Gi
+  Capabilities:
+    persistence: true
+    block: true
+    fsGroup: true
+    exec: true
+    snapshotDataSource: true
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: true
+    singleNodeVolume: true
+  SupportedFsType:
+    ext3:
+    ext4:
+    xfs:

--- a/test/e2e/testdrivers/1.17.yaml
+++ b/test/e2e/testdrivers/1.17.yaml
@@ -14,8 +14,9 @@
 
 StorageClass:
   FromName: true
-SnapshotClass:
-  FromName: true
+# Disable snapshot tests until we have migrateed to the beta Snapshot API
+#SnapshotClass:
+   #FromName: true
 DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   SupportedSizeRange:
@@ -26,7 +27,8 @@ DriverInfo:
     block: true
     fsGroup: true
     exec: true
-    snapshotDataSource: true
+    # Disable snapshot tests until we have migrateed to the beta Snapshot API
+    snapshotDataSource: false
     multipods: true
     controllerExpansion: true
     nodeExpansion: true


### PR DESCRIPTION
This change adds the Kubernetes 1.17 upstream E2E tests to our CI, validating that our driver is compatible with that Kubernetes release.

One caveat we have is that the Kubernetes 1.17 E2E tests expect the snapshot API to be used in the beta version whereas our driver still uses alpha. We work around this issue by excluding the snapshot-related tests from the 1.17 suite and run run the 1.16 snapshot-only tests against a 1.17 cluster instead. Once we have migrated over to the beta API, we can run the full 1.17 suite again and benefit from the latest snapshot tests in upstream.

The deviation requires making a few adjustments to our E2E test in terms of allowing more flexible combinations of testdriver configuration files and target Kubernetes releases to run the tests against. Similarly, our Github Actions specification is amended to reflect the new CLI flags added to our E2E test, and we add another job for the 1.16 snapshot-only tests leveraging [Github Actions combinations](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations).

Building our runner image for 4 Kubernetes now drives us into a [disk space limitation set on the Github Actions workers](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources), which is why we resort to cleaning up unneeded files from the workers before the start of the build process. (Eventually, we should find a better way to deal with this constraint, perhaps through splitting up our build steps.)

Finally, we include a few improvements to our cluster setup scaffolding to achieve better error reporting and resilience towards transient errors.