### PR TITLE
Enable block support for 1.16 snasphot-only testdriver

### DIFF
--- a/test/e2e/testdrivers/1.16.snapshot-only.yaml
+++ b/test/e2e/testdrivers/1.16.snapshot-only.yaml
@@ -20,7 +20,7 @@ DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   Capabilities:
     persistence: false
-    block: false
+    block: true
     fsGroup: false
     exec: false
     snapshotDataSource: true


### PR DESCRIPTION
Unlike other testdriver flags, the "block" flag value determines the expected outcome of a specific test based on if a driver supports block mode access (which ours does).