### PR TITLE
e2e: propagate container run exit code upwards

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -473,7 +473,7 @@ func deployDriver(ctx context.Context, driverImage string, kubeconfigFile, token
 // runE2ETests invokes our test container.
 // It passes in bind-mount parameters for the kubeconfig and the location of the
 // testdriver YAML files.
-func runE2ETests(ctx context.Context, kubeVersion, runnerImage, testdriverFilename, focus, kubeconfigFile, token string, skipParallel, skipSequential bool, ginkgoNodes int) (retErr error) {
+func runE2ETests(ctx context.Context, kubeVersion, runnerImage, testdriverFilename, focus, kubeconfigFile, token string, skipParallel, skipSequential bool, ginkgoNodes int) error {
 	testdriverDirectoryInContainer := "/testdrivers"
 	testdriverFilenameInContainer := filepath.Join(testdriverDirectoryInContainer, filepath.Base(testdriverFilename))
 

--- a/test/e2e/testdrivers/1.16.snapshot-only.yaml
+++ b/test/e2e/testdrivers/1.16.snapshot-only.yaml
@@ -19,15 +19,15 @@ SnapshotClass:
 DriverInfo:
   Name: dobs.csi.digitalocean.com-dev
   Capabilities:
-    persistence: false
+    persistence: true
     block: true
-    fsGroup: false
+    fsGroup: true
     exec: false
     snapshotDataSource: true
-    multipods: false
+    multipods: true
     controllerExpansion: false
     nodeExpansion: false
     volumeLimits: false
-    singleNodeVolume: false
+    singleNodeVolume: true
   SupportedFsType:
     ext4:


### PR DESCRIPTION
This fixes a bug where a container run returning with a non-zero exit code would not be propagated upwards properly, thus making actually failed runs pass.

As a consequence, we also have to toggle a few flags for the 1.16 snapshot-only testdriver configuration to make the E2E tests actually pass.