### PR TITLE
Upgrade csi-test to v3.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/kubernetes-csi/csi-test/v3 v3.1.1-0.20200422103951-b91f2543e6e7
+	github.com/kubernetes-csi/csi-test/v3 v3.1.1
 	github.com/kubernetes-csi/external-snapshotter v0.4.1
 	github.com/magiconair/properties v1.8.1
 	github.com/sirupsen/logrus v1.4.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -90,7 +90,7 @@ github.com/imdario/mergo
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/kubernetes-csi/csi-test/v3 v3.1.1-0.20200422103951-b91f2543e6e7 => github.com/digitalocean/csi-test/v3 v3.1.1-0.20200422215505-20e87c55f1f6
+# github.com/kubernetes-csi/csi-test/v3 v3.1.1 => github.com/digitalocean/csi-test/v3 v3.1.1-0.20200422215505-20e87c55f1f6
 ## explicit
 github.com/kubernetes-csi/csi-test/v3/pkg/sanity
 github.com/kubernetes-csi/csi-test/v3/utils


### PR DESCRIPTION
This replaces our temporary fork added in #301 which was needed until all custom changes had been merged upstream.