### PR TITLE
Add missing 1.17 container image deletes

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -15,6 +15,6 @@ jobs:
         run: |
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.14" "${BRANCH}-tests-1.15" "${BRANCH}-tests-1.16" "${BRANCH}-builder" "${BRANCH}-builder-pre-1.16")
+          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.14" "${BRANCH}-tests-1.15" "${BRANCH}-tests-1.16" "${BRANCH}-tests-1.17" "${BRANCH}-builder" "${BRANCH}-builder-pre-1.16")
           for i in ${images[*]}; do curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
           curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -78,6 +78,7 @@ Command-line arguments are passed as-in to the test tool. Run `e2e.sh -h` for us
 1. Add a new testdriver YAML configuration file
 1. Extend the list of supported Kubernetes releases in `e2e_test.go`
 1. Extend the list of tested Kubernetes releases in `.github/workflows/test.yaml`
+1. Extend the list of deleted container images in `.github/workflows/delete.yaml`
 
 ### handle-image.sh
 


### PR DESCRIPTION
We missed to update our delete CI step to clean up PR images when we added support for Kubernetes 1.17.