### PR TITLE
Replace irritating usage of sed with in-place edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmd/do-csi-plugin/do-csi-plugin
 .idea/
+*.sedbak

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ bump-version:
 	@echo "Bumping VERSION from $(VERSION) to $(NEW_VERSION)"
 	@echo $(NEW_VERSION) > VERSION
 	@cp deploy/kubernetes/releases/csi-digitalocean-latest.yaml deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
-	@sed -i'' -e 's#digitalocean/do-csi-plugin:dev#digitalocean/do-csi-plugin:${NEW_VERSION}#g' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
+	@sed -i.sedbak 's#digitalocean/do-csi-plugin:dev#digitalocean/do-csi-plugin:${NEW_VERSION}#g' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
 	@git add --intent-to-add deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
-	@sed -i'' -e '/^# This file is only for development use/d' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
+	@sed -i.sedbak '/^# This file is only for development use/d' deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml
 	$(eval NEW_DATE = $(shell date +%Y.%m.%d))
-	@sed -i'' -e 's/## unreleased/## ${NEW_VERSION} - ${NEW_DATE}/g' CHANGELOG.md
+	@sed -i.sedbak 's/## unreleased/## ${NEW_VERSION} - ${NEW_DATE}/g' CHANGELOG.md
 	@ echo '## unreleased\n' | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
-	@rm -f deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml-e CHANGELOG.md-e
+	@rm -f deploy/kubernetes/releases/csi-digitalocean-${NEW_VERSION}.yaml.sedbak CHANGELOG.md.sedbak
 
 .PHONY: compile
 compile:

--- a/scripts/update-k8s.sh
+++ b/scripts/update-k8s.sh
@@ -39,5 +39,5 @@ go mod tidy
 go mod vendor
 set +x
 
-sed -i -e "s/^KUBERNETES_VERSION.*/KUBERNETES_VERSION ?= $KUBERNETES_VERSION/" Makefile
-rm Makefile-e
+sed -i.sedbak "s/^KUBERNETES_VERSION.*/KUBERNETES_VERSION ?= $KUBERNETES_VERSION/" Makefile
+rm -f Makefile.sedbak

--- a/scripts/update-k8s.sh
+++ b/scripts/update-k8s.sh
@@ -40,3 +40,4 @@ go mod vendor
 set +x
 
 sed -i -e "s/^KUBERNETES_VERSION.*/KUBERNETES_VERSION ?= $KUBERNETES_VERSION/" Makefile
+rm Makefile-e


### PR DESCRIPTION
~One of sed's peculiarities is that it leaves behind backup files with a `-e` suffix. Unfortunately, it is not easy to skip those in an operating system-agnostic way.~

Our (portable) usage of `sed -i` is rather irritating because it gives the impression that we use sed's `-e` parameter when instead this becomes our backup suffix. We replace this kind of usage by a more straight-forward syntax.

See [my comment below](https://github.com/digitalocean/csi-digitalocean/pull/319#discussion_r436249610) on the differences between BSD and GNU sed, and why there's no way to omit backup files in a portable fashion.