### PR TITLE
e2e: handle 429 TooManyRequests error

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-TIMEOUT="${TIMEOUT:-30m}"
+TIMEOUT="${TIMEOUT:-1h}"
 
 (
   cd "${SCRIPT_DIR}"


### PR DESCRIPTION
During the polling for the cluster create request to finish, we frequently fail because we have used up all of our API quota budget. In particular, this can happen when multiple e2e tests are running
concurrently.

This change addresses the problem why handling a seen 429 with some extra sleep time to replenish our API request budget.

We also bump the involved timeouts to account for the extra test time we might need now.