### PR TITLE
Update csi-resizer to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* Update csi-resizer sidecar to v0.5.0
+  [[GH-324]](https://github.com/digitalocean/csi-digitalocean/pull/324)
+
 ## v1.3.0 - 2020.05.05
 
 * Fix ListVolumes paging

--- a/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-latest.yaml
@@ -180,7 +180,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
The update does not provide any specific functionality we need, but it is a good idea to stay up to date.