### PR TITLE
Fix apply instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ digitalocean          Opaque                                1         18h
 Before you continue, be sure to checkout to a [tagged
 release](https://github.com/digitalocean/csi-digitalocean/releases). Always use the [latest version](https://github.com/digitalocean/csi-digitalocean/releases) compatible with your Kubernetes release (see the [compatibility information](#kubernetes-compatibility)).
 
-The [releases directory](deploy/kubernetes/releases) directory holds manifests for all plugin releases. You can deploy a specific version by executing the command
+The [releases directory](deploy/kubernetes/releases) holds manifests for all plugin releases. You can deploy a specific version by executing the command
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z.yaml
+kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z
 ```
 
-where `vX.Y.Z` is the plugin target version.
+where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file.)
 
 If you see any issues during the installation, this could be because the newly
 created CRDs haven't been established yet. If you call `kubectl apply -f` again

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ release](https://github.com/digitalocean/csi-digitalocean/releases). Always use 
 The [releases directory](deploy/kubernetes/releases) holds manifests for all plugin releases. You can deploy a specific version by executing the command
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z
+kubectl apply -f deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z
 ```
 
 where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file.)

--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ digitalocean          Opaque                                1         18h
 
 #### 2. Deploy the CSI plugin and sidecars
 
-Before you continue, be sure to checkout to a [tagged
-release](https://github.com/digitalocean/csi-digitalocean/releases). Always use the [latest version](https://github.com/digitalocean/csi-digitalocean/releases) compatible with your Kubernetes release (see the [compatibility information](#kubernetes-compatibility)).
+Always use the [latest version](https://github.com/digitalocean/csi-digitalocean/releases) compatible with your Kubernetes release (see the [compatibility information](#kubernetes-compatibility)).
 
 The [releases directory](deploy/kubernetes/releases) holds manifests for all plugin releases. You can deploy a specific version by executing the command
 
 ```shell
-kubectl apply -f deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z
+# Do *not* add a blank after -f
+kubectl apply -fdeploy/kubernetes/releases/csi-digitalocean-vX.Y.Z/{crds.yaml,driver.yaml,snapshot-controller.yaml}
 ```
 
-where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you can replace `csi-digitalocean-vX.Y.Z` with `csi-digitalocean-vX.Y.Z.yaml`).
+where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you need to use `kubectl apply -fdeploy/kubernetes/releases/csi-digitalocean-vX.Y.Z`)
 
 If you see any issues during the installation, this could be because the newly
 created CRDs haven't been established yet. If you call `kubectl apply -f` again

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The [releases directory](deploy/kubernetes/releases) holds manifests for all plu
 kubectl apply -fhttps://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z/{crds.yaml,driver.yaml,snapshot-controller.yaml}
 ```
 
-where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you need to use `kubectl apply -fdeploy/kubernetes/releases/csi-digitalocean-vX.Y.Z`)
+where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you need to use `kubectl apply -fhttps://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z.yaml`)
 
 If you see any issues during the installation, this could be because the newly
 created CRDs haven't been established yet. If you call `kubectl apply -f` again

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Always use the [latest version](https://github.com/digitalocean/csi-digitalocean
 The [releases directory](deploy/kubernetes/releases) holds manifests for all plugin releases. You can deploy a specific version by executing the command
 
 ```shell
-# Do *not* add a blank after -f
-kubectl apply -fdeploy/kubernetes/releases/csi-digitalocean-vX.Y.Z/{crds.yaml,driver.yaml,snapshot-controller.yaml}
+# Do *not* add a blank space after -f
+kubectl apply -fhttps://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z/{crds.yaml,driver.yaml,snapshot-controller.yaml}
 ```
 
 where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you need to use `kubectl apply -fdeploy/kubernetes/releases/csi-digitalocean-vX.Y.Z`)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The [releases directory](deploy/kubernetes/releases) holds manifests for all plu
 kubectl apply -f deploy/kubernetes/releases/csi-digitalocean-vX.Y.Z
 ```
 
-where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file.)
+where `vX.Y.Z` is the plugin target version. (Note that for releases older than v2.0.0, the driver was contained in a single YAML file. If you'd like to deploy an older release you can replace `csi-digitalocean-vX.Y.Z` with `csi-digitalocean-vX.Y.Z.yaml`).
 
 If you see any issues during the installation, this could be because the newly
 created CRDs haven't been established yet. If you call `kubectl apply -f` again

--- a/deploy/kubernetes/releases/README.md
+++ b/deploy/kubernetes/releases/README.md
@@ -1,0 +1,5 @@
+# releases
+
+This directory holds manifests for all released versions.
+
+**Note to maintainers:** If a new manifest is added below the release-specific directory, make sure to also update the deployment instructions in the top-level README.


### PR DESCRIPTION
We recently restructured our per-version manifests to be located in sub-directories. This change updates our README accordingly.

Fixes #331.