### PR TITLE
Ensure target and staging paths are deleted on test start

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -95,6 +95,12 @@ func TestDriverSuite(t *testing.T) {
 	})
 
 	cfg := sanity.NewTestConfig()
+	if err := os.RemoveAll(cfg.TargetPath); err != nil {
+		t.Fatalf("failed to delete target path %s: %s", cfg.TargetPath, err)
+	}
+	if err := os.RemoveAll(cfg.StagingPath); err != nil {
+		t.Fatalf("failed to delete staging path %s: %s", cfg.StagingPath, err)
+	}
 	cfg.Address = endpoint
 	cfg.IdempotentCount = 5
 	cfg.TestNodeVolumeAttachLimit = true


### PR DESCRIPTION
While csi-test / csi-sanity ensures that the paths are deleted after test completion, the cleanup cannot apply when tests fail hard (e.g., due to a panic). Thus, we do an extra cleanup step at test start time to ensure the test suite does not fail due to left-over files.