### PR TITLE
Fix built-in release version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,12 +41,13 @@ jobs:
       - name: Log into container registry
         run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin
 
-      - name: tag new CSI plugin release image
+      # Rebuild plugin instead of just promoting the latest :master image so
+      # that the right version is correctly baked into the release via the -X
+      # flag.
+      - name: Build and push released plugin image
         run: |
-          TAG=$(git describe --tags)
-          docker pull ${DOCKER_ORG}/do-csi-plugin:master
-          docker tag ${DOCKER_ORG}/do-csi-plugin:master ${DOCKER_ORG}/do-csi-plugin:${TAG}
-          docker push ${DOCKER_ORG}/do-csi-plugin:${TAG}
+          VERSION="$(git describe --tags)"
+          DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
 
       - name: create Github release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,12 +77,12 @@ jobs:
           RUNNER_IMAGE_TAG_PREFIX: ${{ github.head_ref }}
         run: RUNNER_IMAGE=${DOCKER_ORG}/k8s-e2e-test-runner make runner-push
 
-      - name: Build and push plugin image
+      - name: Build and push development plugin image
         env:
           VERSION: ${{ github.head_ref }}
         run: |
           VERSION="${VERSION:-latest}"
-          DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin-dev make compile build push
+          DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin-dev make publish
 
   e2e-test:
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 
 all: check-unused test
 
-publish: compile build push clean
+publish: clean compile build push
 
 .PHONY: update-k8s
 update-k8s:


### PR DESCRIPTION
In #274, we started to release container images by promoting/retagging the latest `:master` image. However, this did not yield an updated version string baked into the binary; instead, we ended up with the _latest_ version used when we build the latest master.

This change modifies the release Github Action by recompiling and packaging the binary so that the right version is included.