### PR TITLE
Reference Github Actions by hash

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2036a08  # v2.3.2
         with:
           fetch-depth: 1
 
@@ -49,7 +49,7 @@ jobs:
           docker push ${DOCKER_ORG}/do-csi-plugin:${TAG}
 
       - name: create Github release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b7e450d  # v0.1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2036a08  # v2.3.2
         with:
           fetch-depth: 1
 
       - name: Go setup
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@8a3a76c  # v2.1.2
         with:
           go-version: '1.14.2'
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2036a08  # v2.3.2
         with:
           fetch-depth: 1
 
@@ -93,12 +93,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2036a08  # v2.3.2
         with:
           fetch-depth: 1
 
       - name: Go setup
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@8a3a76c  # v2.1.2
         with:
           go-version: '1.14.2'
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2036a08  # v2.3.2
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
This is considered a safer practice since branch references bear the risk of a malicious (or hijacked) Action sneaking in privileged code.