### PR TITLE
e2e: implement several improvements and fixes

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -24,5 +24,5 @@ TIMEOUT="${TIMEOUT:-1h}"
 
 (
   cd "${SCRIPT_DIR}"
-  go test -v -tags e2e -test.timeout "${TIMEOUT}" ./... -args -long "$@"
+  DEBUG_E2E="${DEBUG_E2E:-}" go test -v -tags e2e -test.timeout "${TIMEOUT}" ./... -args -long "$@"
 )

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -492,6 +492,10 @@ func runE2ETests(ctx context.Context, kubeVersion, runnerImage, testdriverFilena
 		"KUBECONFIG=/root/.kube/config",
 	}
 
+	if debug := os.Getenv("DEBUG_E2E"); debug != "" {
+		envs = append(envs, "DEBUG_E2E=1")
+	}
+
 	if focus != "" {
 		fmt.Printf("Setting focus to %q\n", focus)
 		envs = append(envs, fmt.Sprintf("FOCUS=%s", focus))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -533,6 +533,7 @@ func runE2ETests(ctx context.Context, kubeVersion, runnerImage, testdriverFilena
 		stopTimeout: 1 * time.Minute,
 	}
 
+	fmt.Printf("Starting test runner image %q for Kubernetes version %q\n", runnerImage, kubeVersion)
 	return runContainer(ctx, p)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -492,6 +492,11 @@ func runE2ETests(ctx context.Context, kubeVersion, runnerImage, testdriverFilena
 		"KUBECONFIG=/root/.kube/config",
 	}
 
+	if focus != "" {
+		fmt.Printf("Setting focus to %q\n", focus)
+		envs = append(envs, fmt.Sprintf("FOCUS=%s", focus))
+	}
+
 	if skipParallel {
 		envs = append(envs, fmt.Sprintf("%s=1", envVarSkipTestsParallel))
 	}

--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${DEBUG_E2E:-}" ]]; then
+  set -o xtrace
+fi
+
 readonly DEFAULT_GINKGO_NODES=10
 
 if [[ $# -ne 2 ]]; then

--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -48,7 +48,7 @@ fi
 
 focus=
 if [[ "${FOCUS:-}" ]]; then
-  focus=".*${focus}"
+  focus=".*${FOCUS}"
 fi
 
 if [[ "${SKIP_PARALLEL_TESTS:-}" ]]; then
@@ -57,7 +57,7 @@ else
   echo 'Running parallel tests'
   # Set node count explicitly since node detection does not work properly inside a
   # container.
-  ginkgo -v -p -nodes "${GINKGO_NODES:-$DEFAULT_GINKGO_NODES}" -focus="External.Storage${focus}" -skip='\[Feature:|\[Disruptive\]|\[Serial\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+  ginkgo -v -p -nodes "${GINKGO_NODES:-$DEFAULT_GINKGO_NODES}" -focus="External.Storage${focus}.*" -skip='\[Feature:|\[Disruptive\]|\[Serial\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
 fi
 
 if [[ "${SKIP_SEQUENTIAL_TESTS:-}" ]]; then


### PR DESCRIPTION
- Pass through focus switch correctly.
- Support `DEBUG_E2E` flag to enable `xtrace` on e2e runner script.
- Log used test runner image and Kubernetes version.