### PR TITLE
Run e2e tests for 1.19

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -15,6 +15,6 @@ jobs:
         run: |
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.18" "${BRANCH}-tests-1.17" "${BRANCH}-builder")
+          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.19" "${BRANCH}-tests-1.18" "${BRANCH}-tests-1.17" "${BRANCH}-builder")
           for i in ${images[*]}; do curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
           curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.18', '1.17']
+        kube-release: ['1.19', '1.18', '1.17']
 
     steps:
       - name: checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.19', '1.18', '1.17']
+        kube-release: ['1.19.2-do.0', '1.18', '1.17']
 
     steps:
       - name: checkout

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ runner-build:
 	@echo "pulling cache images"
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):builder || true
+	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 || true
+	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.19 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.18 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 || true
@@ -146,10 +148,20 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder -f test/e2e/Dockerfile test/e2e
 
+	@echo "building target tests-1.19"
+	@docker build --target tests-1.19 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
+		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 -f test/e2e/Dockerfile test/e2e
+
 	@echo "building target tests-1.18"
 	@docker build --target tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.18 \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 -f test/e2e/Dockerfile test/e2e
@@ -158,6 +170,8 @@ runner-build:
 	@docker build --target tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
@@ -168,6 +182,8 @@ runner-build:
 	@docker build --target tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
@@ -180,6 +196,8 @@ runner-build:
 	@docker build --target runtime \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
@@ -194,6 +212,8 @@ runner-build:
 	@docker build \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17 \
@@ -208,6 +228,7 @@ runner-build:
 
 runner-push: runner-build
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder
+	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Kubernetes Release | DigitalOcean CSI Driver Version
 1.16               | v1.3.x
 1.17               | v2.0.x (v1.3.x with v1alpha1 snapshots only)
 1.18               | v2.0.x (v1.3.x with v1alpha1 snapshots only)
+1.19               | v2.0.x (v1.3.x with v1alpha1 snapshots only)
 
 ---
 **Note:**

--- a/scripts/get-e2etest-sha256.sh
+++ b/scripts/get-e2etest-sha256.sh
@@ -18,30 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly IMAGE=${IMAGE:-digitalocean/k8s-e2e-test-runner}
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-usage() {
-  echo "$(basename "$0") build | push"
-}
 
 if [[ $# -ne 1 ]]; then
-  usage >&2
+  echo "$(basename "$0") <Kubernetes version, e.g., 1.42.23>" >&2
   exit 1
 fi
 
-readonly OPERATION="$1"
+readonly KUBE_VERSION="$1"
 
-case "${OPERATION}" in
-  build)
-    docker build -t "${IMAGE}" --build-arg KUBE_VERSION_1_19 --build-arg KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM --build-arg KUBE_VERSION_1_18 --build-arg KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM --build-arg SHA_1_17 -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
-    ;;
-  
-  push)
-    docker push "${IMAGE}"
-    ;;
-
-  *)
-    usage >&2
-    exit 1
-esac
+curl --fail --location "https://dl.k8s.io/v${KUBE_VERSION}/kubernetes-test-linux-amd64.tar.gz" | tar xvzOf - --strip-components 3 kubernetes/test/bin/e2e.test | sha256sum | awk '{print $1}'

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -20,10 +20,19 @@ RUN apt-get update && \
 RUN mkdir -p /go/src/k8s.io
 WORKDIR /go/src/k8s.io
 
+### Kubernetes 1.19
+FROM builder AS tests-1.19
+ARG KUBE_VERSION_1_19=1.19.2
+ARG KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM=0ef80e3f74a9d115b7b2e74f8bcca9e2f93d69cd7b3b45cafc74c13c3799cad7
+
+RUN curl --fail --location https://dl.k8s.io/v${KUBE_VERSION_1_19}/kubernetes-test-linux-amd64.tar.gz | tar xvzf - --strip-components 3 kubernetes/test/bin/e2e.test
+RUN echo "${KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --check
+RUN cp e2e.test /e2e.1.19.test
+
 ### Kubernetes 1.18
 FROM builder AS tests-1.18
-ARG KUBE_VERSION_1_18=1.18.3
-ARG KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM=07f7582ffddf817b087efc7098cfd2e9eb458eb59ae5b71b8db26e8a8debee16
+ARG KUBE_VERSION_1_18=1.18.9
+ARG KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM=aa0f78b42580970fbfe29690efff8d386d32819044f7a99f69ec5ffad836e8ac
 
 RUN curl --fail --location https://dl.k8s.io/v${KUBE_VERSION_1_18}/kubernetes-test-linux-amd64.tar.gz | tar xvzf - --strip-components 3 kubernetes/test/bin/e2e.test
 RUN echo "${KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --check
@@ -49,7 +58,7 @@ ARG DOCTL_VERSION=1.36.0
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.
-ARG KUBECTL_VERSION=1.18.3
+ARG KUBECTL_VERSION=1.19.2
 
 RUN curl --fail --location --output /tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini
 RUN chmod u+x /tini
@@ -69,6 +78,7 @@ FROM bitnami/minideb:buster AS runtime
 # Certificates needed to trust the CA for any HTTPS connections to the DO API.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends ca-certificates
+COPY --from=tests-1.19 /e2e.1.19.test /
 COPY --from=tests-1.18 /e2e.1.18.test /
 COPY --from=tests-1.17 /e2e.1.17.test /
 COPY --from=tools /tini /sbin/

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -70,15 +70,16 @@ Command-line arguments are passed as-in to the test tool. Run `e2e.sh -h` for us
 
 ### Add support for a new Kubernetes release
 
-1. Make and push any necessary updates to our Kubernetes fork
-1. Add a new Kubernetes version-specific block to the runner image Dockerfile; make sure to update the `SHA_*` variable as well
-1. Update the kubectl version in the test runner Dockerfile
-1. Update the Makefile `runner-build` and `runner-push` targets
-1. Extend the `SHA_*` variables in the `handle-images.sh` script
-1. Add a new testdriver YAML configuration file
-1. Extend the list of supported Kubernetes releases in `e2e_test.go`
-1. Extend the list of tested Kubernetes releases in `.github/workflows/test.yaml`
-1. Extend the list of deleted container images in `.github/workflows/delete.yaml`
+1. Make and push any necessary updates to our Kubernetes fork.
+1. Add a new Kubernetes version-specific block to the runner image Dockerfile; make sure to update the `SHA_*` commit hash and/or `*_SHA256_*` e2e.test binary checksum variables as well. (You can use `scripts/get-e2etest-sha256` to generate the e2e.test binary checksum for a given Kubernetes version.)
+1. Update the kubectl version in the test runner Dockerfile.
+1. Update the Makefile `runner-build` and `runner-push` targets.
+1. Extend the Kubernetes release-specific build arguments in the `handle-images.sh` script.
+1. Add a new testdriver YAML configuration file.
+1. Extend the list of supported Kubernetes releases in `e2e_test.go`.
+1. Extend the list of tested Kubernetes releases in `.github/workflows/test.yaml`.
+1. Extend the list of deleted container images in `.github/workflows/delete.yaml`.
+1. Update the [_Kubernetes Compatibility_ matrix](/README.md#kubernetes_compatibility) in the README file.
 
 ### handle-image.sh
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,7 +55,7 @@ var (
 	errTokenMissing = errors.New("token must be specified in DIGITALOCEAN_ACCESS_TOKEN environment variable")
 
 	// De-facto global variables that require initialization at runtime.
-	supportedKubernetesVersions     = []string{"1.18", "1.17"}
+	supportedKubernetesVersions     = []string{"1.19", "1.18", "1.17"}
 	sourceFileDir                   string
 	testdriverDirectoryAbsolutePath string
 	deployScriptPath                string

--- a/test/e2e/testdrivers/1.19.yaml
+++ b/test/e2e/testdrivers/1.19.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: dobs.csi.digitalocean.com-dev
+  SupportedSizeRange:
+    Max: 100Gi
+    Min: 1Gi
+  Capabilities:
+    persistence: true
+    block: true
+    fsGroup: true
+    exec: true
+    snapshotDataSource: true
+    pvcDataSource: false
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: true
+    singleNodeVolume: true
+  SupportedFsType:
+    ext3:
+    ext4:
+    xfs:


### PR DESCRIPTION
This change adds 1.19 to the list of Kubernetes versions we run e2e tests for.

Other drive-improvements include:

- Add script `get-e2etest-sha256.sh` to get the SHA256 sum of a e2e.test binary of a given Kubernetes release (needed to update the e2e test runner Dockerfile image).
- Update the "How to add support for a new Kubernetes release" checklist.