### PR TITLE
Reclaim unused local volumes space

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,7 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
+          docker volume prune -f
 
       - name: build and push runner image
         env:


### PR DESCRIPTION
Delete unused local volumes if present. As we increase building images for newer versions, clearing up space as much as possible makes sense so as to stay within the limits for GH hosted runners