### PR TITLE
Reclaim unused local volumes space

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -16,5 +16,5 @@ jobs:
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
           images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.18" "${BRANCH}-tests-1.17" "${BRANCH}-builder")
-          for i in ${images[*]}; do curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
-          curl -s -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/
+          for i in ${images[*]}; do curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
+          curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean
-          docker rmi $(docker image ls -aq)
+          docker system prune -af --volumes
           df -h
 
       - name: build and push runner image


### PR DESCRIPTION
Delete unused local volumes if present. As we increase building images for newer versions, clearing up space as much as possible makes sense so as to stay within the limits for GH hosted runners