### PR TITLE
Update csi-provisioner to v2.0.2 and csi-snapshotter to v3.0.0

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.1
+          image: quay.io/k8scsi/csi-provisioner:v2.0.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -100,7 +100,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+          image: quay.io/k8scsi/csi-snapshotter:v3.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.1.1
+          image: quay.io/k8scsi/snapshot-controller:v3.0.0
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
csi-provisioner v2.0.2 brings a small watch optimization that is actually not relevant for. However, it is still good to be on the latest
version.

csi-snapshotter v3.0.0 brings stricter validation and several bugfixes. The breaking changes pertain to Go interface adjustments (e.g., snapshotter using context when talking to the API server) which do not affect us since we consume the binary only.