### PR TITLE
Allow releasing from tag in Github Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and push released plugin image
         run: |
           VERSION="$(git describe --tags)"
-          DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
+          I_KNOW_WHAT_IAM_DOING=1 DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
 
       - name: create Github release
         uses: softprops/action-gh-release@b7e450d  # v0.1.5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,8 +23,7 @@ on:
   push:
     tags-ignore:
       # The tags below are for Kubernetes <1.14 which are not supported by the
-      # upstream end-to-end tests. We should find a different way to
-      # automatically test and release them. For now though, ignore them.
+      # upstream end-to-end tests and are not actively maintained anymore.
       - v0.*
       - v1.0.*
 
@@ -47,7 +46,7 @@ jobs:
       - name: Build and push released plugin image
         run: |
           VERSION="$(git describe --tags)"
-          I_KNOW_WHAT_IAM_DOING=1 DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
+          DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
 
       - name: create Github release
         uses: softprops/action-gh-release@b7e450d  # v0.1.5

--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,16 @@ build:
 
 .PHONY: push
 push:
-ifeq ($(DOCKER_REPO),digitalocean/do-csi-plugin)
-  ifneq ($(BRANCH),master)
-    ifneq ($(VERSION),dev)
-	  $(error "Only the `dev` tag can be published from non-master branches")
+# Permit releasing to the canonical container repository if we are on master or use the "dev" tag on a non-master
+# branch.
+# Make an exception when the I_KNOW_WHAT_IAM_DOING environment flag is set, which we need when releasing via Github
+# Actions where HEAD (qualifying as a non-master branch) is checked out.
+ifeq ($(I_KNOW_WHAT_IAM_DOING),)
+  ifeq ($(DOCKER_REPO),digitalocean/do-csi-plugin)
+    ifneq ($(BRANCH),master)
+      ifneq ($(VERSION),dev)
+	    $(error "Only the `dev` tag can be published from non-master branches")
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
Our Makefile contains an (ugly) chain of conditions to prevent releasing anything but the `dev` tag from a non-master branch. This breaks our release after we moved to rebuilding instead of just retagging (#342).

We solve the matter by requiring a semver `$VERSION` in the `push` target, which is exactly what our release action already provides.