### PR TITLE
Match semver without bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build:
 push:
 # Permit releasing to the canonical container repository only if VERSION adheres to semver.
 ifeq ($(DOCKER_REPO),digitalocean/do-csi-plugin)
-	@[[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$$ ]] || ( echo "VERSION "${VERSION}" does not adhere to semver"; exit 1 )
+	@echo "${VERSION}" | grep -Eq "^v[0-9]+\.[0-9]+\.[0-9]+$$" || ( echo "VERSION \"${VERSION}\" does not adhere to semver"; exit 1 )
 endif
 	@echo "==> Publishing $(DOCKER_REPO):$(VERSION)"
 	@docker push $(DOCKER_REPO):$(VERSION)


### PR DESCRIPTION
Makefile and Github Actions provides `/bin/sh` by default which does not support `[[`. We use grep instead which is just as good as more easily available.