### PR TITLE
Match csi-provisioner RBAC rules with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* Match csi-provisioner RBAC rules with upstream
+  [[GH-360]](https://github.com/digitalocean/csi-digitalocean/pull/360)
+
 ## v2.1.0 - 2020.10.07
 
 * Surface health check failures

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -165,9 +165,6 @@ metadata:
   name: csi-do-provisioner-role
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
@@ -185,6 +182,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
The RBAC rules for csi-privisioner were missing permissions for csinodes and nodes that [upstream defines](https://github.com/kubernetes-csi/external-provisioner/blob/080d35df20983a57cc0d1da514b1654822998e94/deploy/kubernetes/rbac.yaml#L19-L59). The end-to-end tests still worked fine because other sidecars also happened to provide the missing rules. Adding them explicitly to the provisioner is still a good idea to be decoupled from other sidecars, and to educate users that may want to use separate service accounts on what the RBAC rules for the individual sidecars must look like.

Finally, we also remove secrets permissions from the provisioner since DO block storages do not require any.