### PR TITLE
e2e: run tests against 1.19 minor version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.19.2-do.0', '1.18', '1.17']
+        kube-release: ['1.19', '1.18', '1.17']
 
     steps:
       - name: checkout


### PR DESCRIPTION
Now that 1.19 is publicly released, we can reference the minor version and let the DOKS service resolve it to the latest patch release.