### PR TITLE
Address CVE-2020-8569

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.2
+          image: quay.io/k8scsi/csi-provisioner:v2.0.4
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.0
+          image: quay.io/k8scsi/csi-attacher:v3.0.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -101,7 +101,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v3.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v3.0.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -113,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.0
+          image: quay.io/k8scsi/csi-resizer:v1.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v3.0.0
+          image: quay.io/k8scsi/snapshot-controller:v3.0.2
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Bump snapshotter to v3.0.2.

Piggyback other sidecars updates as well even though the patch releases do not affect our usage.