### PR TITLE
ci: use long commit hashes when referencing Github Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@2036a08  # v2.3.2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           fetch-depth: 1
 
@@ -49,7 +49,7 @@ jobs:
           DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
 
       - name: create Github release
-        uses: softprops/action-gh-release@b7e450d  # v0.1.5
+        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf  # v0.1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@2036a08  # v2.3.2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           fetch-depth: 1
 
       - name: Go setup
-        uses: actions/setup-go@37335c7  # v2.1.3
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8  # v2.1.3
         with:
           go-version: '1.15.5'
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@2036a08  # v2.3.2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           fetch-depth: 1
 
@@ -93,12 +93,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@2036a08  # v2.3.2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           fetch-depth: 1
 
       - name: Go setup
-        uses: actions/setup-go@37335c7  # v2.1.3
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8  # v2.1.3
         with:
           go-version: '1.15.5'
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@2036a08  # v2.3.2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
This prevents against attackers who forcefully try to provoke a prefix collision.

Also use the opportunity to patch level-upgrade `actions/checkout` and `softprops/action-gh-release`.