### PR TITLE
Use less startup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ Kubernetes Release | DigitalOcean CSI Driver Version
 The [DigitalOcean Kubernetes](https://www.digitalocean.com/products/kubernetes/) product comes with the CSI driver pre-installed and no further steps are required.
 
 ---
+**Driver modes:**
+
+By default, driver runs in both controller and node mode. It would create disk Volumes on DigitalOcean infrastructure and mount them on the required node.
+
+Driver can be run in **controller only mode** outside DigitalOcean droplets.
+To use this mode `--region` flag (valid DigitalOcean region slug) must be provided together with `--token` flag (DigitalOcean API token).
+
+Alternatively driver can be run in **node only mode** on DigitalOcean droplets. Driver would only handle node related requests like mount volume.
+To us this mode `--region` and `--token` flags must not be provided.
+
+Skip secret creation (section 1. in following deployment instructions) when using **node only mode** as API token is not required.
+
+---
 
 **Requirements:**
 

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -30,16 +30,14 @@ import (
 
 func main() {
 	var (
-		endpoint     = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
-		token        = flag.String("token", "", "DigitalOcean access token.")
-		url          = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
-		isController = flag.Bool("controller-mode", true, "Run driver with controller mode.")
-		isNode       = flag.Bool("node-mode", true, "Run driver with node mode.")
-		region       = flag.String("region", "", "DO region slug. Required when running in controller only mode. Don't use if running in Node Mode.")
-		doTag        = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
-		driverName   = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
-		debugAddr    = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
-		version      = flag.Bool("version", false, "Print the version and exit.")
+		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
+		token      = flag.String("token", "", "DigitalOcean access token.")
+		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
+		region     = flag.String("region", "", "DigitalOcean region slug. Required when running not on DigitalOcean droplet.")
+		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
+		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
+		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
+		version    = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -48,11 +46,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *isController && *token == "" {
-		log.Fatalln("token required when running with controller-mode")
+	if *token == "" && *region != "" {
+		log.Fatalln("region flag must not be set when driver is running in node mode (with unset token flag)")
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *isController, *isNode, *region, *doTag, *driverName, *debugAddr)
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *region, *doTag, *driverName, *debugAddr)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -30,13 +30,16 @@ import (
 
 func main() {
 	var (
-		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint")
-		token      = flag.String("token", "", "DigitalOcean access token")
-		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL")
-		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach")
-		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver")
-		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on")
-		version    = flag.Bool("version", false, "Print the version and exit.")
+		endpoint     = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
+		token        = flag.String("token", "", "DigitalOcean access token.")
+		url          = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
+		isController = flag.Bool("controller-mode", true, "Run driver with controller mode.")
+		isNode       = flag.Bool("node-mode", true, "Run driver with node mode.")
+		region       = flag.String("region", "", "DO region slug. Required when running in controller only mode. Don't use if running in Node Mode.")
+		doTag        = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
+		driverName   = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
+		debugAddr    = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
+		version      = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -45,7 +48,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *doTag, *driverName, *debugAddr)
+	if *isController && *token == "" {
+		log.Fatalln("token required when running with controller-mode")
+	}
+
+	drv, err := driver.NewDriver(*endpoint, *token, *url, *isController, *isNode, *region, *doTag, *driverName, *debugAddr)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -94,7 +94,7 @@ type Driver struct {
 // NewDriver returns a CSI plugin that contains the necessary gRPC
 // interfaces to interact with Kubernetes over unix domain sockets for
 // managing DigitalOcean Block Storage
-func NewDriver(ep, token, url, doTag, driverName, debugAddr string) (*Driver, error) {
+func NewDriver(ep, token, url string, isController, isNode bool, region, doTag, driverName, debugAddr string) (*Driver, error) {
 	if driverName == "" {
 		driverName = DefaultDriverName
 	}
@@ -104,13 +104,16 @@ func NewDriver(ep, token, url, doTag, driverName, debugAddr string) (*Driver, er
 	})
 	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 
-	all, err := metadata.NewClient().Metadata()
-	if err != nil {
-		return nil, fmt.Errorf("couldn't get metadata: %s (are you running on DigitalOcean droplets?)", err)
-	}
+	var hostID string
+	if isNode || isController && region == "" {
+		all, err := metadata.NewClient().Metadata()
+		if err != nil {
+			return nil, fmt.Errorf("couldn't get metadata: %s (are you running on DigitalOcean droplets? Provide region configuration if running in controller only mode)", err)
+		}
 
-	region := all.Region
-	hostID := strconv.Itoa(all.DropletID)
+		region = all.Region
+		hostID = strconv.Itoa(all.DropletID)
+	}
 
 	opts := []godo.ClientOpt{}
 	opts = append(opts, godo.SetBaseURL(url))
@@ -137,16 +140,14 @@ func NewDriver(ep, token, url, doTag, driverName, debugAddr string) (*Driver, er
 		name:                  driverName,
 		publishInfoVolumeName: driverName + "/volume-name",
 
-		doTag:     doTag,
-		endpoint:  ep,
-		debugAddr: debugAddr,
-		hostID:    func() string { return hostID },
-		region:    region,
-		mounter:   newMounter(log),
-		log:       log,
-		// for now we're assuming only the controller has a non-empty token. In
-		// the future we should pass an explicit flag to the driver.
-		isController:      token != "",
+		doTag:             doTag,
+		endpoint:          ep,
+		debugAddr:         debugAddr,
+		hostID:            func() string { return hostID },
+		region:            region,
+		mounter:           newMounter(log),
+		log:               log,
+		isController:      isController,
 		waitActionTimeout: defaultWaitActionTimeout,
 
 		storage:        doClient.Storage,


### PR DESCRIPTION
- Remove isController and isNode flags.
- Error if token flag is not provided, but region flag is provided. Region flag is not required as driver is running in node mode on DigitalOcean droplet.
- Add documentation about available driver modes.