### PR TITLE
Update sidecar versions and add 1.20 e2e tests

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -15,6 +15,6 @@ jobs:
         run: |
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.19" "${BRANCH}-tests-1.18" "${BRANCH}-tests-1.17" "${BRANCH}-builder")
+          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.20" "${BRANCH}-tests-1.19" "${BRANCH}-tests-1.18" "${BRANCH}-tests-1.17" "${BRANCH}-builder")
           for i in ${images[*]}; do curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
           curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.19', '1.18', '1.17']
+        kube-release: ['1.20', '1.19', '1.18', '1.17']
 
     steps:
       - name: checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Bump sidecar versions and add 1.20 e2e tests
+  [[GH-380]](https://github.com/digitalocean/csi-digitalocean/pull/380)
 * Update Kubernetes dependency to 1.20.2
   [[GH-374]](https://github.com/digitalocean/csi-digitalocean/pull/374)
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifneq ($(VERSION),)
 else
   VERSION ?= $(shell cat VERSION)
 endif
-KUBERNETES_VERSION ?= 1.19.2
+KUBERNETES_VERSION ?= 1.20.2
 DOCKER_REPO ?= digitalocean/do-csi-plugin
 CANONICAL_RUNNER_IMAGE = digitalocean/k8s-e2e-test-runner
 RUNNER_IMAGE ?= $(CANONICAL_RUNNER_IMAGE)
@@ -125,6 +125,8 @@ runner-build:
 	@echo "pulling cache images"
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):builder || true
+	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 || true
+	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.20 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.19 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 || true
@@ -144,10 +146,20 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder -f test/e2e/Dockerfile test/e2e
 
+	@echo "building target tests-1.20"
+	@docker build --target tests-1.20 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
+		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 -f test/e2e/Dockerfile test/e2e
+
 	@echo "building target tests-1.19"
 	@docker build --target tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 -f test/e2e/Dockerfile test/e2e
@@ -156,6 +168,8 @@ runner-build:
 	@docker build --target tests-1.18 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
@@ -166,6 +180,8 @@ runner-build:
 	@docker build --target tests-1.17 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
@@ -178,6 +194,8 @@ runner-build:
 	@docker build --target tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
@@ -192,6 +210,8 @@ runner-build:
 	@docker build --target runtime \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
@@ -208,6 +228,8 @@ runner-build:
 	@docker build \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.20 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.19 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18 \
@@ -224,6 +246,7 @@ runner-build:
 
 runner-push: runner-build
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder
+	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.20
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.19
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.18
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.17

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.4
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.2
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -101,7 +101,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v3.0.2
+          image: quay.io/k8scsi/csi-snapshotter:v3.0.3
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -113,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.1
+          image: quay.io/k8scsi/csi-resizer:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -358,7 +358,7 @@ spec:
               mountPath: /etc/udev/rules.d/
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v3.0.2
+          image: quay.io/k8scsi/snapshot-controller:v3.0.3
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -20,6 +20,15 @@ RUN apt-get update && \
 RUN mkdir -p /go/src/k8s.io
 WORKDIR /go/src/k8s.io
 
+### Kubernetes 1.20
+FROM builder AS tests-1.20
+ARG KUBE_VERSION_1_20=1.20.2
+ARG KUBE_VERSION_1_20_E2E_BIN_SHA256_CHECKSUM=6610c2f933e7eeab6611fe0744cb742398f70d39d411f881e4f91ba600cf2f33
+
+RUN curl --fail --location https://dl.k8s.io/v${KUBE_VERSION_1_20}/kubernetes-test-linux-amd64.tar.gz | tar xvzf - --strip-components 3 kubernetes/test/bin/e2e.test
+RUN echo "${KUBE_VERSION_1_20_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --check
+RUN cp e2e.test /e2e.1.20.test
+
 ### Kubernetes 1.19
 FROM builder AS tests-1.19
 ARG KUBE_VERSION_1_19=1.19.2
@@ -58,7 +67,7 @@ ARG DOCTL_VERSION=1.36.0
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.
-ARG KUBECTL_VERSION=1.19.2
+ARG KUBECTL_VERSION=1.20.2
 
 RUN curl --fail --location --output /tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini
 RUN chmod u+x /tini
@@ -78,6 +87,7 @@ FROM bitnami/minideb:buster AS runtime
 # Certificates needed to trust the CA for any HTTPS connections to the DO API.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends ca-certificates
+COPY --from=tests-1.20 /e2e.1.20.test /
 COPY --from=tests-1.19 /e2e.1.19.test /
 COPY --from=tests-1.18 /e2e.1.18.test /
 COPY --from=tests-1.17 /e2e.1.17.test /

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,7 +55,7 @@ var (
 	errTokenMissing = errors.New("token must be specified in DIGITALOCEAN_ACCESS_TOKEN environment variable")
 
 	// De-facto global variables that require initialization at runtime.
-	supportedKubernetesVersions     = []string{"1.19", "1.18", "1.17"}
+	supportedKubernetesVersions     = []string{"1.20", "1.19", "1.18", "1.17"}
 	sourceFileDir                   string
 	testdriverDirectoryAbsolutePath string
 	deployScriptPath                string

--- a/test/e2e/handle-image.sh
+++ b/test/e2e/handle-image.sh
@@ -34,7 +34,7 @@ readonly OPERATION="$1"
 
 case "${OPERATION}" in
   build)
-    docker build -t "${IMAGE}" --build-arg KUBE_VERSION_1_19 --build-arg KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM --build-arg KUBE_VERSION_1_18 --build-arg KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM --build-arg SHA_1_17 -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    docker build -t "${IMAGE}" --build-arg KUBE_VERSION_1_20 --build-arg KUBE_VERSION_1_20_E2E_BIN_SHA256_CHECKSUM --build-arg KUBE_VERSION_1_19 --build-arg KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM --build-arg KUBE_VERSION_1_18 --build-arg KUBE_VERSION_1_18_E2E_BIN_SHA256_CHECKSUM --build-arg SHA_1_17 -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
     ;;
   
   push)

--- a/test/e2e/testdrivers/1.20.yaml
+++ b/test/e2e/testdrivers/1.20.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: dobs.csi.digitalocean.com-dev
+  SupportedSizeRange:
+    Max: 100Gi
+    Min: 1Gi
+  Capabilities:
+    persistence: true
+    block: true
+    fsGroup: true
+    exec: true
+    snapshotDataSource: true
+    pvcDataSource: false
+    multipods: true
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: true
+    singleNodeVolume: true
+  SupportedFsType:
+    ext3:
+    ext4:
+    xfs:


### PR DESCRIPTION
Update sidecar versions to the latest, staying on the 3.x shapshotter series since we don't support v1 snapshots yet and 4.x supports only Kubernetes 1.20+.

Add 1.20 to the e2e tests to validate that everything is working on 1.20 before cutting a release.