### PR TITLE
Use k8s mount library to implement NodeUnpublishVolume

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -266,19 +266,9 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	})
 	log.Info("node unpublish volume called")
 
-	mounted, err := d.mounter.IsMounted(req.TargetPath)
+	err := d.mounter.Unmount(req.TargetPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if mounted {
-		log.Info("unmounting the target path")
-		err := d.mounter.Unmount(req.TargetPath)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Info("target path is already unmounted")
 	}
 
 	log.Info("unmounting volume is finished")


### PR DESCRIPTION
Allows us to use a higher level abstraction for handling umounts.