### PR TITLE
Update sidecar dependencies

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccount: csi-do-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.4
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -101,7 +101,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -113,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.1
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"


### PR DESCRIPTION
In particular, bump csi-snapshotter to v3.0.3 which is the last (patch) release for v3 as of now. This is in preparation to updating to csi-snapshotter v4 which changes the behavior around invalid snapshots and thus requires a new major release of our CSI driver.