### PR TITLE
snapshot-migration: Allow for nil deletionPolicy in v1alpha1 snapshots

### DIFF
--- a/cmd/migrate-snapshots/main.go
+++ b/cmd/migrate-snapshots/main.go
@@ -201,9 +201,18 @@ func writeVolumeSnapshotContents(ctx context.Context, client dynamic.Namespaceab
 			return 0, fmt.Errorf("failed get v1alpha1/VolumeSnapshotContent.spec.volumeSnapshotRef.namespace for %s: %s", name, err)
 		}
 
-		deletionPolicy, _, err := unstructured.NestedString(alphaSnapContent.Object, "spec", "deletionPolicy")
+		deletionPolicyPtr, _, err := unstructured.NestedFieldNoCopy(alphaSnapContent.Object, "spec", "deletionPolicy")
 		if err != nil {
 			return 0, fmt.Errorf("failed get v1alpha1/VolumeSnapshotContent.spec.deletionPolicy for %s: %s", name, err)
+		}
+		// Delete is the default policy.
+		deletionPolicy := "Delete"
+		if deletionPolicyPtr != nil {
+			deletionPolicyStrPtr, ok := deletionPolicyPtr.(*string)
+			if !ok {
+				return 0, fmt.Errorf("v1alpha1/VolumeSnapshotContent.spec.deletionPolicy is type %T; expected *string", deletionPolicyPtr)
+			}
+			deletionPolicy = *deletionPolicyStrPtr
 		}
 
 		csiVolSnapSourceSnapHandleStr, found, err := unstructured.NestedString(alphaSnapContent.Object, "spec", "csiVolumeSnapshotSource", "snapshotHandle")

--- a/cmd/migrate-snapshots/main_test.go
+++ b/cmd/migrate-snapshots/main_test.go
@@ -256,6 +256,7 @@ func TestWriteVolumeSnapshotObjectsContent(t *testing.T) {
 						Source: v1beta1snapshot.VolumeSnapshotContentSource{
 							SnapshotHandle: pointer.StringPtr("12cb8633-f3b2-422a-bc64-eef690c17f14"),
 						},
+						DeletionPolicy: v1beta1snapshot.VolumeSnapshotContentDelete,
 					},
 				},
 				{
@@ -275,6 +276,7 @@ func TestWriteVolumeSnapshotObjectsContent(t *testing.T) {
 						Source: v1beta1snapshot.VolumeSnapshotContentSource{
 							SnapshotHandle: pointer.StringPtr("69e7bb48-c1a6-41fe-b090-6f17f6bfd862"),
 						},
+						DeletionPolicy: v1beta1snapshot.VolumeSnapshotContentDelete,
 					},
 				},
 			},


### PR DESCRIPTION
In v1alpha1, the `deletionPolicy` of a volume snapshot contents's `spec` is optional, and thus can be nil. Handle the nil case and treat it as the default (`Delete`).
