### PR TITLE
Add snapshot validation webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,14 @@ default-token-jskxx   kubernetes.io/service-account-token   3         18h
 digitalocean          Opaque                                1         18h
 ```
 
-#### 2. Deploy the CSI plugin and sidecars
+#### 2. Provide authentication data for the snapshot validation webhook
+
+Snapshots are validated through a `ValidatingWebhookConfiguration` which requires proper CA, certificate, and key data. The manifests in `snapshot-validation-webhook.yaml` should provide sufficient scaffolding to inject the data accordingly. However, the details on how to create and manage them is up to the user and dependent on the exact environment the webhook runs in. See the `XXX`-marked comments in the manifests file for user-required injection points. 
+
+The [official snapshot webhook example](https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/webhook-example) offers a non-production-ready solution suitable for testing. For full production readiness, something like [cert-manager](https://cert-manager.io/) can be leveraged. 
+
+
+#### 3. Deploy the CSI plugin and sidecars
 
 Always use the [latest release](https://github.com/digitalocean/csi-digitalocean/releases) compatible with your Kubernetes release (see the [compatibility information](#kubernetes-compatibility)).
 
@@ -198,7 +205,7 @@ If you see any issues during the installation, this could be because the newly
 created CRDs haven't been established yet. If you call `kubectl apply -f` again
 on the same file, the missing resources will be applied again.
 
-#### 3. Test and verify
+#### 4. Test and verify
 
 Create a PersistentVolumeClaim. This makes sure a volume is created and provisioned on your behalf:
 

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-validation-webhook.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-validation-webhook.yaml
@@ -1,0 +1,88 @@
+# Copyright 2021 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "validation-webhook.snapshot.storage.k8s.io"
+webhooks:
+  - name: "validation-webhook.snapshot.storage.k8s.io"
+    rules:
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1", "v1beta1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["volumesnapshots", "volumesnapshotcontents"]
+        scope:       "*"
+    clientConfig:
+      service:
+        namespace: "kube-system"
+        name: "snapshot-validation-service"
+        path: "/volumesnapshot"
+      # XXX Uncomment and populate the CA bundle field accordingly if a dedicated
+      # CA is to be used.
+      # caBundle: ${CA_BUNDLE}
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 5
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snapshot-validation
+  namespace: kube-system
+  labels:
+    app: snapshot-validation
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: snapshot-validation
+  template:
+    metadata:
+      labels:
+        app: snapshot-validation
+    spec:
+      containers:
+        - name: snapshot-validation
+          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v3.0.3
+          imagePullPolicy: IfNotPresent
+          args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
+          ports:
+            - containerPort: 443
+          volumeMounts:
+            - name: snapshot-validation-webhook-certs
+              mountPath: /etc/snapshot-validation-webhook/certs
+              readOnly: true
+      volumes:
+        - name: snapshot-validation-webhook-certs
+          secret:
+            # XXX Populate the secret properly with a certificate and key
+            secretName: snapshot-validation-secret
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: snapshot-validation-service
+  namespace: kube-system
+spec:
+  selector:
+    app: snapshot-validation
+  ports:
+    - protocol: TCP
+      port: 443

--- a/scripts/create-cert.sh
+++ b/scripts/create-cert.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# File originally from https://github.com/banzaicloud/admission-webhook-example/blob/blog/deployment/webhook-create-signed-cert.sh
+
+set -e
+
+usage() {
+    cat <<EOF
+Generate certificate suitable for use with a webhook service.
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+The server key/cert k8s CA cert are stored in a k8s secret.
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --service)
+            service="$2"
+            shift
+            ;;
+        --secret)
+            secret="$2"
+            shift
+            ;;
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=admission-webhook-example-svc
+[ -z ${secret} ] && secret=admission-webhook-example-certs
+[ -z ${namespace} ] && namespace=default
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=system:node:${service}.${namespace}.svc;/O=system:nodes" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kubelet-serving
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run=client -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/scripts/patch-ca-bundle.sh
+++ b/scripts/patch-ca-bundle.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# File originally from https://github.com/banzaicloud/admission-webhook-example/blob/blog/deployment/webhook-patch-ca-bundle.sh
+
+ROOT=$(cd $(dirname $0)/../../; pwd)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CA_BUNDLE=$(kubectl config view --raw -o json | jq -r '.clusters[0].cluster."certificate-authority-data"' | tr -d '"')
+
+if command -v envsubst >/dev/null 2>&1; then
+    envsubst
+else
+    sed -e "s|\${CA_BUNDLE}|${CA_BUNDLE}|g"
+fi


### PR DESCRIPTION
Add the snapshot validation webhook responsible for labeling invalid snapshots. This is the recommended approach in preparation to installing snapshots v1.

See [the upstream docs](https://github.com/kubernetes-csi/external-snapshotter/tree/138d310e5d2d102fcf90df96d7a8aaf6690ce76e#validating-webhook) for details.