### PR TITLE
e2e: do not set platform to fix running on Mac

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/digitalocean/csi-digitalocean
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/container-storage-interface/spec v1.3.0
-	github.com/containerd/containerd v1.5.8
+	github.com/containerd/containerd v1.5.8 // indirect
 	github.com/digitalocean/go-metadata v0.0.0-20180111002115-15bd36e5f6f7
 	github.com/digitalocean/godo v1.29.0
 	github.com/docker/docker v20.10.2+incompatible

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -51,7 +50,7 @@ type containerParams struct {
 // It returns an error when the container startup or cleanup fails, or when the
 // container returns a non-zero exit code.
 func runContainer(ctx context.Context, p containerParams) (retErr error) {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return fmt.Errorf("failed to create Docker client: %s", err)
 	}
@@ -117,7 +116,6 @@ Summaries:
 		})
 	}
 
-	platform := platforms.DefaultSpec()
 	stopTimeoutSecs := int(p.stopTimeout.Seconds())
 	cont, err := cli.ContainerCreate(ctx,
 		&container.Config{
@@ -135,7 +133,7 @@ Summaries:
 			Mounts:     mounts,
 		},
 		&network.NetworkingConfig{},
-		&platform,
+		nil,
 		e2eContainerName,
 	)
 	if err != nil {


### PR DESCRIPTION
Newer versions of Docker seem to fail when using the default platform since Darwin on amd64 has become a dedicated image architecture with Docker:

```
e2e_test.go:284: end-to-end tests failed: failed to create container: Error response from daemon: image with reference docker.io/digitalocean/k8s-e2e-test-runner:latest was found but does not match the specified platform: wanted darwin/amd64, actual: linux/amd64
```

Not setting the platform ensures the Linux image is requested.