### PR TITLE
Mark CSI driver as default container

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -68,6 +68,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: csi-do-plugin
       labels:
         app: csi-do-controller
         role: csi-do
@@ -336,6 +338,8 @@ spec:
       app: csi-do-node
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: csi-do-plugin
       labels:
         app: csi-do-node
         role: csi-do


### PR DESCRIPTION
Adding the [official annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) to mark the CSI driver container as the default one so that it gets automatically selected by `kubectl {logs,exec}` unless a more specific container is chosen via `-c`.