### PR TITLE
driver: remove unnecessary waitActionTimeout

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -1008,12 +1008,6 @@ func (d *Driver) waitAction(ctx context.Context, log *logrus.Entry, volumeID str
 		"action_id": actionID,
 	})
 
-	// This timeout should not strike given all sidecars use a timeout that is
-	// lower (which should always be the case). Using this as a fail-safe
-	// mechanism in case of a bug or misconfiguration.
-	ctx, cancel := context.WithTimeout(ctx, d.waitActionTimeout)
-	defer cancel()
-
 	err := wait.PollUntil(1*time.Second, wait.ConditionFunc(func() (done bool, err error) {
 		action, _, err := d.storageActions.Get(ctx, volumeID, actionID)
 		if err != nil {

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -457,7 +457,6 @@ func TestWaitAction(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			d := Driver{
-				waitActionTimeout: test.timeout,
 				storageActions: &fakeStorageAction{
 					fakeStorageActionsDriver: &fakeStorageActionsDriver{},
 					storageGetValsFunc:       test.storageGetValsFunc,

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -464,8 +464,9 @@ func TestWaitAction(t *testing.T) {
 				log: logrus.New().WithField("test_enabed", true),
 			}
 
+			ctx, _ := context.WithTimeout(context.Background(), test.timeout)
 			err := d.waitAction(
-				context.Background(),
+				ctx,
 				logrus.New().WithField("test_enabed", true),
 				"volumeID",
 				42,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -41,8 +41,7 @@ import (
 const (
 	// DefaultDriverName defines the name that is used in Kubernetes and the CSI
 	// system for the canonical, official name of this plugin
-	DefaultDriverName        = "dobs.csi.digitalocean.com"
-	defaultWaitActionTimeout = 1 * time.Minute
+	DefaultDriverName = "dobs.csi.digitalocean.com"
 )
 
 var (
@@ -63,13 +62,12 @@ type Driver struct {
 	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
 	publishInfoVolumeName string
 
-	endpoint          string
-	debugAddr         string
-	hostID            func() string
-	region            string
-	doTag             string
-	isController      bool
-	waitActionTimeout time.Duration
+	endpoint     string
+	debugAddr    string
+	hostID       func() string
+	region       string
+	doTag        string
+	isController bool
 
 	srv     *grpc.Server
 	httpSrv *http.Server
@@ -151,8 +149,7 @@ func NewDriver(ep, token, url, region, doTag, driverName, debugAddr string) (*Dr
 		mounter:   newMounter(log),
 		log:       log,
 		// we're assuming only the controller has a non-empty token.
-		isController:      token != "",
-		waitActionTimeout: defaultWaitActionTimeout,
+		isController: token != "",
 
 		storage:        doClient.Storage,
 		storageActions: doClient.StorageActions,

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -94,11 +94,10 @@ func TestDriverSuite(t *testing.T) {
 			dropletIdx++
 			return strconv.Itoa(droplets[i+1].ID)
 		},
-		doTag:             doTag,
-		region:            "nyc3",
-		waitActionTimeout: defaultWaitActionTimeout,
-		mounter:           fm,
-		log:               logrus.New().WithField("test_enabed", true),
+		doTag:   doTag,
+		region:  "nyc3",
+		mounter: fm,
+		log:     logrus.New().WithField("test_enabed", true),
 
 		storage: &fakeStorageDriver{
 			volumes:   volumes,


### PR DESCRIPTION
This came up in discussion of https://jira.internal.digitalocean.com/browse/CON-6582 where we determined that this timeout is unnecessary due to the timeout that gets set on the gRPC method call context.