### PR TITLE
Make volumes page size customizable

### DIFF
--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -30,14 +30,15 @@ import (
 
 func main() {
 	var (
-		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
-		token      = flag.String("token", "", "DigitalOcean access token.")
-		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
-		region     = flag.String("region", "", "DigitalOcean region slug. Specify only when running in controller mode outside of a DigitalOcean droplet.")
-		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
-		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
-		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
-		version    = flag.Bool("version", false, "Print the version and exit.")
+		endpoint               = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
+		token                  = flag.String("token", "", "DigitalOcean access token.")
+		url                    = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
+		region                 = flag.String("region", "", "DigitalOcean region slug. Specify only when running in controller mode outside of a DigitalOcean droplet.")
+		doTag                  = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
+		driverName             = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
+		debugAddr              = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
+		defaultVolumesPageSize = flag.Uint("default-volumes-page-size", 0, "The default page size used when paging through volumes results (default: do not specify and let the DO API choose)")
+		version                = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -50,7 +51,16 @@ func main() {
 		log.Fatalln("region flag must not be set when driver is running in node mode (i.e., token flag is unset)")
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *region, *doTag, *driverName, *debugAddr)
+	drv, err := driver.NewDriver(driver.NewDriverParams{
+		Endpoint:               *endpoint,
+		Token:                  *token,
+		URL:                    *url,
+		Region:                 *region,
+		DOTag:                  *doTag,
+		DriverName:             *driverName,
+		DebugAddr:              *debugAddr,
+		DefaultVolumesPageSize: *defaultVolumesPageSize,
+	})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -516,10 +516,16 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 
 // ListVolumes returns a list of all requested volumes
 func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	maxEntries := req.MaxEntries
+	if maxEntries == 0 && d.defaultVolumesPageSize > 0 {
+		maxEntries = int32(d.defaultVolumesPageSize)
+	}
+
 	log := d.log.WithFields(logrus.Fields{
-		"max_entries":        req.MaxEntries,
-		"req_starting_token": req.StartingToken,
-		"method":             "list_volumes",
+		"max_entries":           req.MaxEntries,
+		"effective_max_entries": maxEntries,
+		"req_starting_token":    req.StartingToken,
+		"method":                "list_volumes",
 	})
 	log.Info("list volumes called")
 
@@ -532,7 +538,7 @@ func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 		startingToken = int32(parsedToken)
 	}
 
-	untypedVolumes, nextToken, err := listResources(ctx, log, startingToken, req.MaxEntries, func(ctx context.Context, listOpts *godo.ListOptions) ([]interface{}, *godo.Response, error) {
+	untypedVolumes, nextToken, err := listResources(ctx, log, startingToken, maxEntries, func(ctx context.Context, listOpts *godo.ListOptions) ([]interface{}, *godo.Response, error) {
 		volListOpts := &godo.ListVolumeParams{
 			ListOptions: listOpts,
 			Region:      d.region,
@@ -583,7 +589,7 @@ func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 		resp.NextToken = strconv.FormatInt(int64(nextToken), 10)
 	}
 
-	log.WithField("response", resp).Info("volumes listed")
+	log.WithField("num_volume_entries", len(resp.Entries)).Info("volumes listed")
 	return resp, nil
 }
 


### PR DESCRIPTION
This is in support for accounts having a large number of volumes, allowing periodic resyncs through the csi-attacher to become more efficient and less heavy in terms of number of API calls needed.

We also stop showing all volumes listed since that also has the potential to clutter the logs on accounts with many volumes.