### PR TITLE
ci: delete associated resources on cleanup

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -62,7 +62,7 @@ FROM golang:1.13 AS tools
 ARG TINI_VERSION=0.18.0
 # doctl is needed to support clusters that had their kubeconfig fetched via the
 # CLI because those leverage a kubeconfig authentication plugin based on doctl.
-ARG DOCTL_VERSION=1.36.0
+ARG DOCTL_VERSION=1.76.2
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.

--- a/test/e2e/cleanup-clusters.sh
+++ b/test/e2e/cleanup-clusters.sh
@@ -37,9 +37,7 @@ echo "Cleaning up clusters based on cluster tag: ${CLUSTER_TAG}"
 while read -r cluster_uuid; do
   if doctl kubernetes cluster get "${cluster_uuid}" --no-header --format Tags | grep -q "${CLUSTER_TAG}"; then
     echo "Deleting cluster ${cluster_uuid}"
-    doctl kubernetes cluster delete -f "${cluster_uuid}"
-    echo "Deleting volumes for cluster ${cluster_uuid}"
-    doctl compute volume list --no-header --format ID,Tags | grep "k8s:${cluster_uuid}" | awk '{print $1}' | xargs -n 1 doctl compute volume delete -f
+    doctl kubernetes cluster delete --dangerous -f "${cluster_uuid}"
   fi
 done < <(doctl kubernetes cluster list --no-header --format ID)   # --format field "Tags" does not work on the "list" command
 echo "Done."


### PR DESCRIPTION
Make sure no volumes and snapshots are left behind when cleaning up clusters on PR close.