### PR TITLE
Set storage size to minimum volume size

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -934,8 +934,8 @@ func (d *Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGet
 
 // extractStorage extracts the storage size in bytes from the given capacity
 // range. If the capacity range is not satisfied it returns the default volume
-// size. If the capacity range is below or above supported sizes, it returns an
-// error.
+// size. If the capacity range is above supported sizes, it returns an
+// error. If the capacity range is below supported size, it returns the minimum supported size
 func (d *Driver) extractStorage(capRange *csi.CapacityRange) (int64, error) {
 	if capRange == nil {
 		return defaultVolumeSizeInBytes, nil
@@ -956,9 +956,9 @@ func (d *Driver) extractStorage(capRange *csi.CapacityRange) (int64, error) {
 
 	if requiredSet && !limitSet && requiredBytes < minimumVolumeSizeInBytes {
 		d.log.WithFields(logrus.Fields{
-			"requiredBytes":            formatBytes(requiredBytes),
-			"minimumVolumeSizeInBytes": formatBytes(minimumVolumeSizeInBytes),
-		}).Warn("requiredBytes is less than minimum supported volume size, setting requiredBytes default to minimumVolumeSizeBytes")
+			"required_bytes":      formatBytes(requiredBytes),
+			"minimum_volume_size": formatBytes(minimumVolumeSizeInBytes),
+		}).Warn("requiredBytes is less than minimum volume size, setting requiredBytes default to minimumVolumeSizeBytes")
 		return minimumVolumeSizeInBytes, nil
 	}
 

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -206,8 +206,8 @@ func TestControllerExpandVolume(t *testing.T) {
 					RequiredBytes: 0.5 * giB,
 				},
 			},
-			resp: nil,
-			err:  status.Error(codes.OutOfRange, "ControllerExpandVolume invalid capacity range: required (512Mi) can not be less than minimum supported volume size (1Gi)"),
+			resp: &csi.ControllerExpandVolumeResponse{CapacityBytes: minimumVolumeSizeInBytes, NodeExpansionRequired: true},
+			err:  nil,
 		},
 		{
 			name: "volume for corresponding volume id does not exist",


### PR DESCRIPTION
Setting required Bytes to minimum volume size (1Gi) in case it is less than the minimum volume size.

Tested locally and works as expected.

Input pvc & pod for test:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1
  storageClassName: do-block-storage
---
kind: Pod
apiVersion: v1
metadata:
  name: my-csi-app
spec:
  containers:
    - name: my-frontend
      image: busybox
      volumeMounts:
      - mountPath: "/data"
        name: my-do-volume
      command: [ "sleep", "1000000" ]
  volumes:
    - name: my-do-volume
      persistentVolumeClaim:
        claimName: csi-pvc

```
Logs for reference:

`
time="2022-06-24T16:23:44Z" level=warning msg="requiredBytes is less than minimum supported volume size, setting requiredBytes default to minimumVolumeSizeBytes" host_id=303920350 minimumVolumeSizeInBytes=1Gi region=blr1 requiredBytes=1 version=v4.1.0
`
```
kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS       REASON   AGE
pvc-934a18e6-ab6e-47a9-8e4f-d736e75ca7e6   1Gi        RWO            Delete           Bound    default/csi-pvc   do-block-storage            4m17s
```
