### PR TITLE
Backport master changes into release-3.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout
@@ -41,13 +41,13 @@ jobs:
       - name: Go setup
         uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8  # v2.1.3
         with:
-          go-version: '1.17.2'
+          go-version: '1.17.7'
 
       - name: Run unit tests
         run: make all
 
   push-images:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: unit-test
 
     steps:
@@ -85,7 +85,7 @@ jobs:
           DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin-dev make publish
 
   e2e-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: push-images
     strategy:
       matrix:
@@ -100,7 +100,7 @@ jobs:
       - name: Go setup
         uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8  # v2.1.3
         with:
-          go-version: '1.17.2'
+          go-version: '1.17.7'
 
       - name: Install kustomize
         env:
@@ -135,7 +135,7 @@ jobs:
           TIMEOUT=60m make test-e2e E2E_ARGS="-ginkgo-nodes ${NUM_GINKGO_NODES} -driver-image ${DOCKER_ORG}/do-csi-plugin-dev:${TAG} -runner-image ${DOCKER_ORG}/k8s-e2e-test-runner:${RUNNER_IMAGE_TAG_PREFIX}latest -name-suffix ${NAME_SUFFIX} -retain ${{ matrix.kube-release }}"
 
   tag-new-master-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master'
     needs: e2e-test
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 NAME=do-csi-plugin
 OS ?= linux
-GO_VERSION := 1.15.5
+GO_VERSION := 1.17.7
 ifeq ($(strip $(shell git status --porcelain 2>/dev/null)),)
   GIT_TREE_STATE=clean
 else

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifneq ($(VERSION),)
 else
   VERSION ?= $(shell cat VERSION)
 endif
-KUBERNETES_VERSION ?= 1.19.2
+KUBERNETES_VERSION ?= 1.19.15
 DOCKER_REPO ?= digitalocean/do-csi-plugin
 CANONICAL_RUNNER_IMAGE = digitalocean/k8s-e2e-test-runner
 RUNNER_IMAGE ?= $(CANONICAL_RUNNER_IMAGE)

--- a/cmd/do-csi-plugin/Dockerfile
+++ b/cmd/do-csi-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.16
+FROM alpine:3.11
 
 # e2fsprogs-extra is required for resize2fs used for the resize operation
 # blkid: block device identification tool from util-linux

--- a/cmd/do-csi-plugin/Dockerfile
+++ b/cmd/do-csi-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.16
 
 # e2fsprogs-extra is required for resize2fs used for the resize operation
 # blkid: block device identification tool from util-linux

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -30,14 +30,15 @@ import (
 
 func main() {
 	var (
-		endpoint   = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
-		token      = flag.String("token", "", "DigitalOcean access token.")
-		url        = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
-		region     = flag.String("region", "", "DigitalOcean region slug. Specify only when running in controller mode outside of a DigitalOcean droplet.")
-		doTag      = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
-		driverName = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
-		debugAddr  = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
-		version    = flag.Bool("version", false, "Print the version and exit.")
+		endpoint               = flag.String("endpoint", "unix:///var/lib/kubelet/plugins/"+driver.DefaultDriverName+"/csi.sock", "CSI endpoint.")
+		token                  = flag.String("token", "", "DigitalOcean access token.")
+		url                    = flag.String("url", "https://api.digitalocean.com/", "DigitalOcean API URL.")
+		region                 = flag.String("region", "", "DigitalOcean region slug. Specify only when running in controller mode outside of a DigitalOcean droplet.")
+		doTag                  = flag.String("do-tag", "", "Tag DigitalOcean volumes on Create/Attach.")
+		driverName             = flag.String("driver-name", driver.DefaultDriverName, "Name for the driver.")
+		debugAddr              = flag.String("debug-addr", "", "Address to serve the HTTP debug server on.")
+		defaultVolumesPageSize = flag.Uint("default-volumes-page-size", 0, "The default page size used when paging through volumes results (default: do not specify and let the DO API choose)")
+		version                = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
 
@@ -50,7 +51,16 @@ func main() {
 		log.Fatalln("region flag must not be set when driver is running in node mode (i.e., token flag is unset)")
 	}
 
-	drv, err := driver.NewDriver(*endpoint, *token, *url, *region, *doTag, *driverName, *debugAddr)
+	drv, err := driver.NewDriver(driver.NewDriverParams{
+		Endpoint:               *endpoint,
+		Token:                  *token,
+		URL:                    *url,
+		Region:                 *region,
+		DOTag:                  *doTag,
+		DriverName:             *driverName,
+		DebugAddr:              *debugAddr,
+		DefaultVolumesPageSize: *defaultVolumesPageSize,
+	})
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -91,10 +91,12 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--reconcile-sync=30m"
+            - "--timeout=2m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -115,7 +117,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -135,6 +137,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
             - "--url=$(DIGITALOCEAN_API_URL)"
+            - "--default-volumes-page-size=200"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -362,7 +365,7 @@ spec:
               mountPath: /etc/udev/rules.d/
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
@@ -35,7 +35,7 @@ spec:
       labels:
         app: snapshot-controller
     spec:
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
           image: k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3

--- a/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-validation-webhook.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-validation-webhook.yaml
@@ -47,15 +47,21 @@ metadata:
   labels:
     app: snapshot-validation
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: snapshot-validation
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: snapshot-validation
     spec:
+      serviceAccountName: snapshot-validation
       containers:
         - name: snapshot-validation
           image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v3.0.3
@@ -76,6 +82,14 @@ spec:
 ---
 
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-validation
+  namespace: kube-system
+
+---
+
+apiVersion: v1
 kind: Service
 metadata:
   name: snapshot-validation-service
@@ -86,3 +100,29 @@ spec:
   ports:
     - protocol: TCP
       port: 443
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-validation
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-validation
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-validation
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-validation
+  apiGroup: rbac.authorization.k8s.io

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -457,7 +457,6 @@ func TestWaitAction(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			d := Driver{
-				waitActionTimeout: test.timeout,
 				storageActions: &fakeStorageAction{
 					fakeStorageActionsDriver: &fakeStorageActionsDriver{},
 					storageGetValsFunc:       test.storageGetValsFunc,
@@ -465,8 +464,9 @@ func TestWaitAction(t *testing.T) {
 				log: logrus.New().WithField("test_enabed", true),
 			}
 
+			ctx, _ := context.WithTimeout(context.Background(), test.timeout)
 			err := d.waitAction(
-				context.Background(),
+				ctx,
 				logrus.New().WithField("test_enabed", true),
 				"volumeID",
 				42,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -62,13 +62,13 @@ type Driver struct {
 	// `ControllerPublishVolume` to `NodeStageVolume or `NodePublishVolume`
 	publishInfoVolumeName string
 
-	endpoint          string
-	debugAddr         string
-	hostID            func() string
-	region            string
-	doTag             string
-	isController      bool
-	waitActionTimeout time.Duration
+	endpoint               string
+	debugAddr              string
+	hostID                 func() string
+	region                 string
+	doTag                  string
+	isController           bool
+	defaultVolumesPageSize uint
 
 	srv     *grpc.Server
 	httpSrv *http.Server
@@ -90,21 +90,35 @@ type Driver struct {
 	ready   bool
 }
 
+// NewDriverParams defines the parameters that can be passed to NewDriver.
+type NewDriverParams struct {
+	Endpoint               string
+	Token                  string
+	URL                    string
+	Region                 string
+	DOTag                  string
+	DriverName             string
+	DebugAddr              string
+	DefaultVolumesPageSize uint
+}
+
 // NewDriver returns a CSI plugin that contains the necessary gRPC
 // interfaces to interact with Kubernetes over unix domain sockets for
 // managing DigitalOcean Block Storage
-func NewDriver(ep, token, url, region, doTag, driverName, debugAddr string) (*Driver, error) {
+func NewDriver(p NewDriverParams) (*Driver, error) {
+	driverName := p.DriverName
 	if driverName == "" {
 		driverName = DefaultDriverName
 	}
 
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
-		AccessToken: token,
+		AccessToken: p.Token,
 	})
 	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 
 	mdClient := metadata.NewClient()
-	if region == "" {
+	var region string
+	if p.Region == "" {
 		var err error
 		region, err = mdClient.Region()
 		if err != nil {
@@ -117,8 +131,8 @@ func NewDriver(ep, token, url, region, doTag, driverName, debugAddr string) (*Dr
 	}
 	hostID := strconv.Itoa(hostIDInt)
 
-	opts := []godo.ClientOpt{}
-	opts = append(opts, godo.SetBaseURL(url))
+	var opts []godo.ClientOpt
+	opts = append(opts, godo.SetBaseURL(p.URL))
 
 	if version == "" {
 		version = "dev"
@@ -142,16 +156,17 @@ func NewDriver(ep, token, url, region, doTag, driverName, debugAddr string) (*Dr
 		name:                  driverName,
 		publishInfoVolumeName: driverName + "/volume-name",
 
-		doTag:     doTag,
-		endpoint:  ep,
-		debugAddr: debugAddr,
-		hostID:    func() string { return hostID },
-		region:    region,
-		mounter:   newMounter(log),
-		log:       log,
+		doTag:                  p.DOTag,
+		endpoint:               p.Endpoint,
+		debugAddr:              p.DebugAddr,
+		defaultVolumesPageSize: p.DefaultVolumesPageSize,
+
+		hostID:  func() string { return hostID },
+		region:  region,
+		mounter: newMounter(log),
+		log:     log,
 		// we're assuming only the controller has a non-empty token.
-		isController:      token != "",
-		waitActionTimeout: defaultWaitActionTimeout,
+		isController: p.Token != "",
 
 		storage:        doClient.Storage,
 		storageActions: doClient.StorageActions,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	metadata "github.com/digitalocean/go-metadata"
+	"github.com/digitalocean/go-metadata"
 	"github.com/digitalocean/godo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -41,8 +41,7 @@ import (
 const (
 	// DefaultDriverName defines the name that is used in Kubernetes and the CSI
 	// system for the canonical, official name of this plugin
-	DefaultDriverName        = "dobs.csi.digitalocean.com"
-	defaultWaitActionTimeout = 1 * time.Minute
+	DefaultDriverName = "dobs.csi.digitalocean.com"
 )
 
 var (

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -94,11 +94,10 @@ func TestDriverSuite(t *testing.T) {
 			dropletIdx++
 			return strconv.Itoa(droplets[i+1].ID)
 		},
-		doTag:             doTag,
-		region:            "nyc3",
-		waitActionTimeout: defaultWaitActionTimeout,
-		mounter:           fm,
-		log:               logrus.New().WithField("test_enabed", true),
+		doTag:   doTag,
+		region:  "nyc3",
+		mounter: fm,
+		log:     logrus.New().WithField("test_enabed", true),
 
 		storage: &fakeStorageDriver{
 			volumes:   volumes,

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /go/src/k8s.io
 
 ### Kubernetes 1.19
 FROM builder AS tests-1.19
-ARG KUBE_VERSION_1_19=1.19.2
-ARG KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM=0ef80e3f74a9d115b7b2e74f8bcca9e2f93d69cd7b3b45cafc74c13c3799cad7
+ARG KUBE_VERSION_1_19=1.19.15
+ARG KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM=a4300019eab60fb26580637dc7852589ceaf224dc34af4e4f831fceb9afea258
 
 RUN curl --fail --location https://dl.k8s.io/v${KUBE_VERSION_1_19}/kubernetes-test-linux-amd64.tar.gz | tar xvzf - --strip-components 3 kubernetes/test/bin/e2e.test
 RUN echo "${KUBE_VERSION_1_19_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --check
@@ -39,7 +39,7 @@ ARG DOCTL_VERSION=1.76.2
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.
-ARG KUBECTL_VERSION=1.19.2
+ARG KUBECTL_VERSION=1.19.15
 
 RUN curl --fail --location --output /tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini
 RUN chmod u+x /tini

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -35,7 +35,7 @@ FROM golang:1.13 AS tools
 ARG TINI_VERSION=0.18.0
 # doctl is needed to support clusters that had their kubeconfig fetched via the
 # CLI because those leverage a kubeconfig authentication plugin based on doctl.
-ARG DOCTL_VERSION=1.36.0
+ARG DOCTL_VERSION=1.76.2
 # ginkgo is needed to run the upstream end-to-end tests.
 ARG GINKGO_VERSION=1.10.3
 # kubectl is needed by some tests.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -38,7 +38,7 @@ External storage tests for CSI drivers require a so-called _testdriver_ specific
 
 For posterity, the steps required to define a testdriver and run the tests [are documented upstream](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external). The test runner provided here encapsulate all of this, however, so DigitalOcean CSI driver authors only need to care about updating or adding testdriver files in the `tests` sub-directory. Each file is specific to a particular Kubernetes release and must be named `<major version>.<minor version>.yaml`, e.g., `1.16.yaml`.
 
-Frequently, representing newly supported features in a testdriver file means flipping on additional capabilities [which are documented in-code](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/testsuites/testdriver.go).
+Frequently, representing newly supported features in a testdriver file means flipping on additional capabilities [which are documented in-code](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/framework/testdriver.go).
 
 ### Go files
 

--- a/test/e2e/cleanup-clusters.sh
+++ b/test/e2e/cleanup-clusters.sh
@@ -37,9 +37,7 @@ echo "Cleaning up clusters based on cluster tag: ${CLUSTER_TAG}"
 while read -r cluster_uuid; do
   if doctl kubernetes cluster get "${cluster_uuid}" --no-header --format Tags | grep -q "${CLUSTER_TAG}"; then
     echo "Deleting cluster ${cluster_uuid}"
-    doctl kubernetes cluster delete -f "${cluster_uuid}"
-    echo "Deleting volumes for cluster ${cluster_uuid}"
-    doctl compute volume list --no-header --format ID,Tags | grep "k8s:${cluster_uuid}" | awk '{print $1}' | xargs -n 1 doctl compute volume delete -f
+    doctl kubernetes cluster delete --dangerous -f "${cluster_uuid}"
   fi
 done < <(doctl kubernetes cluster list --no-header --format ID)   # --format field "Tags" does not work on the "list" command
 echo "Done."

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -391,9 +391,11 @@ func createCluster(ctx context.Context, client *godo.Client, nameSuffix, kubeMaj
 		Tags:        []string{"csi-e2e-test", versionTag, fmt.Sprintf("branch-identifier:%s", nameSuffix)},
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{
 			{
-				Name:  clusterName + "-pool",
-				Size:  "s-4vcpu-8gb",
-				Count: 3,
+				Name:      clusterName + "-pool",
+				Size:      "s-4vcpu-8gb",
+				MinNodes:  5,
+				MaxNodes:  20,
+				AutoScale: true,
 			},
 		},
 	})

--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -68,5 +68,6 @@ if [[ "${SKIP_SEQUENTIAL_TESTS:-}" ]]; then
   echo 'Skipping sequential tests'
 else
   echo 'Running sequential tests'
-  ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+  # Note: \[Feature:VolumeSourceXFS\] is to temporarily skip some snapshot/xfs tests added with 1.22 that would also fail on 1.21 and possibly earlier (via manual testing)
+  ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]|\[Feature:VolumeSourceXFS\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
 fi

--- a/test/kubernetes/deploy/kustomization.yaml
+++ b/test/kubernetes/deploy/kustomization.yaml
@@ -20,6 +20,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+- ../../../deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-controller.yaml
+- ../../../deploy/kubernetes/releases/csi-digitalocean-dev/snapshot-validation-webhook.yaml
 nameSuffix: -dev
 images:
 - name: digitalocean/do-csi-plugin
@@ -105,3 +107,12 @@ patchesStrategicMerge:
     name: do-block-storage
     annotations: null
   driver: dobs.csi.digitalocean.com-dev
+- |-
+  apiVersion: admissionregistration.k8s.io/v1
+  kind: ValidatingWebhookConfiguration
+  metadata:
+    name: "validation-webhook.snapshot.storage.k8s.io"
+  webhooks:
+    - name: "validation-webhook.snapshot.storage.k8s.io"
+      clientConfig:
+        caBundle: ${CA_BUNDLE}


### PR DESCRIPTION
- Update CI/pipeline for Kubernetes 1.2{1,2,3}.
- Update test deployment and RBAC rules.
- Improve wait action logic.
- Make volumes page size customizable.
- Update sidecars.