### PR TITLE
Add retain and XFS storage classes

### DIFF
--- a/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
+++ b/deploy/kubernetes/releases/csi-digitalocean-dev/driver.yaml
@@ -49,6 +49,39 @@ allowVolumeExpansion: true
 
 ---
 
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: do-block-storage-retain
+provisioner: dobs.csi.digitalocean.com
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+
+---
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: do-block-storage-xfs
+provisioner: dobs.csi.digitalocean.com
+parameters:
+  fstype: xfs
+allowVolumeExpansion: true
+
+---
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: do-block-storage-xfs-retain
+provisioner: dobs.csi.digitalocean.com
+parameters:
+  fstype: xfs
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+
+---
+
 ##############################################
 ###########                       ############
 ###########   Controller plugin   ############


### PR DESCRIPTION
To make it easier for users to create volumes that have a Retain reclaim policy, use XFS, or a combination thereof.

Fixes #425