### PR TITLE
Revert "Revert "Temporarily disable [Feature:VolumeSourceXFS] tests""

### DIFF
--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -68,5 +68,6 @@ if [[ "${SKIP_SEQUENTIAL_TESTS:-}" ]]; then
   echo 'Skipping sequential tests'
 else
   echo 'Running sequential tests'
-  ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+  # Note: \[Feature:VolumeSourceXFS\] is to temporarily skip some snapshot/xfs tests added with 1.22 that would also fail on 1.21 and possibly earlier (via manual testing)
+  ginkgo -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]|\[Feature:VolumeSourceXFS\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
 fi


### PR DESCRIPTION
Turns out the tests are still failing -- disable them for now again.

This reverts commit 4c652cb882af7370aef56522a9c1878111e1fcd2.