### PR TITLE
Bring back 1.23 support in the CI pipeline

### DIFF
--- a/.github/workflows/delete.yaml
+++ b/.github/workflows/delete.yaml
@@ -15,6 +15,6 @@ jobs:
         run: |
           BRANCH=$(echo -n ${BRANCH} | tr -c '[:alnum:]._-' '-')
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USER}'", "password": "'${DOCKER_PASS}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.26" "${BRANCH}-tests-1.25" "${BRANCH}-tests-1.24" "${BRANCH}-builder")
+          images=("${BRANCH}-latest" "${BRANCH}-runtime" "${BRANCH}-tools" "${BRANCH}-tests-1.26" "${BRANCH}-tests-1.25" "${BRANCH}-tests-1.24" "${BRANCH}-tests-1.23" "${BRANCH}-builder")
           for i in ${images[*]}; do curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/k8s-e2e-test-runner/tags/$i/; done
           curl --fail -sS -X DELETE -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/digitalocean/do-csi-plugin-dev/tags/${BRANCH}/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: push-images
     strategy:
       matrix:
-        kube-release: ['1.26', '1.25', '1.24']
+        kube-release: ['1.26', '1.25', '1.24', '1.23']
 
     steps:
       - name: checkout

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.26 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25 -f test/e2e/Dockerfile test/e2e
@@ -174,7 +174,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.26 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
@@ -186,7 +186,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.26 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
@@ -206,7 +206,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools -f test/e2e/Dockerfile test/e2e
@@ -222,7 +222,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime \
@@ -240,7 +240,7 @@ runner-build:
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
-        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime \

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ runner-build:
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.25 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.24 || true
+	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 || true
+	@docker pull $(CANONICAL_RUNNER_IMAGE):tests-1.23 || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools || true
 	@docker pull $(CANONICAL_RUNNER_IMAGE):tools || true
 	@docker pull $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime || true
@@ -179,6 +181,20 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 -f test/e2e/Dockerfile test/e2e
 
+	@echo "building target tests-1.23"
+	@docker build --target tests-1.23 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):builder \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.26 \
+        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.26 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
+		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
+		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 -f test/e2e/Dockerfile test/e2e
+
 	@echo "building target tools"
 	@docker build --target tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)builder \
@@ -189,6 +205,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
+        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		-t $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools -f test/e2e/Dockerfile test/e2e
@@ -203,6 +221,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
+        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime \
@@ -219,6 +239,8 @@ runner-build:
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.25 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24 \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.24 \
+		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23 \
+        --cache-from $(CANONICAL_RUNNER_IMAGE):tests-1.23 \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools \
 		--cache-from $(CANONICAL_RUNNER_IMAGE):tools \
 		--cache-from $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime \
@@ -232,6 +254,7 @@ runner-push: runner-build
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.26
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.25
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.24
+	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tests-1.23
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)tools
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)runtime
 	@docker push $(RUNNER_IMAGE):$(RUNNER_IMAGE_TAG_PREFIX)latest

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -50,6 +50,16 @@ RUN echo "${KUBE_VERSION_1_24_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --c
 RUN cp e2e.test /e2e.1.24.test
 RUN cp ginkgo /ginkgo-1.24
 
+### Kubernetes 1.23
+FROM builder AS tests-1.23
+ARG KUBE_VERSION_1_23=1.23.7
+ARG KUBE_VERSION_1_23_E2E_BIN_SHA256_CHECKSUM=e1a9a632b7715d4bfbac3322da5d32072eaf544b31a81a6c3df205d0dc0e96b7
+
+RUN curl --fail --location https://dl.k8s.io/v${KUBE_VERSION_1_23}/kubernetes-test-linux-amd64.tar.gz | tar xvzf - --strip-components 3 kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
+RUN echo "${KUBE_VERSION_1_23_E2E_BIN_SHA256_CHECKSUM}" e2e.test | sha256sum --check
+RUN cp e2e.test /e2e.1.23.test
+RUN cp ginkgo /ginkgo-1.23
+
 FROM golang:1.19 AS tools
 # See comment at the bottom on why we need tini.
 ARG TINI_VERSION=0.18.0
@@ -78,6 +88,8 @@ COPY --from=tests-1.25 /e2e.1.25.test /
 COPY --from=tests-1.25 /ginkgo-1.25 /usr/local/bin
 COPY --from=tests-1.24 /e2e.1.24.test /
 COPY --from=tests-1.24 /ginkgo-1.24 /usr/local/bin
+COPY --from=tests-1.23 /e2e.1.23.test /
+COPY --from=tests-1.23 /ginkgo-1.23 /usr/local/bin
 COPY --from=tools /tini /sbin/
 COPY --from=tools /doctl /usr/local/bin/
 COPY --from=tools /kubectl /usr/local/bin/

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,7 +55,7 @@ var (
 	errTokenMissing = errors.New("token must be specified in DIGITALOCEAN_ACCESS_TOKEN environment variable")
 
 	// De-facto global variables that require initialization at runtime.
-	supportedKubernetesVersions     = []string{"1.26", "1.25", "1.24"}
+	supportedKubernetesVersions     = []string{"1.26", "1.25", "1.24", "1.23"}
 	sourceFileDir                   string
 	testdriverDirectoryAbsolutePath string
 	deployScriptPath                string


### PR DESCRIPTION
End-of-life was incorrectly assumed (by me) even though the maintenance support window is still open until February 28, 2023.