### PR TITLE
fixing VolumeSnapshot spec

### DIFF
--- a/examples/kubernetes/import-snapshot/README.md
+++ b/examples/kubernetes/import-snapshot/README.md
@@ -45,8 +45,9 @@ kind: VolumeSnapshot
 metadata:
   name: snapshot-manual
 spec:
+  volumeSnapshotClassName: do-block-storage
   source:
-        volumeSnapshotContentName: snapshotcontent-manual
+    volumeSnapshotContentName: snapshotcontent-manual
 ```
 
 Make sure the name references between the `VolumeSnapshot` and the previously created `VolumeSnapshotContent` line up correctly.

--- a/examples/kubernetes/import-snapshot/README.md
+++ b/examples/kubernetes/import-snapshot/README.md
@@ -45,8 +45,8 @@ kind: VolumeSnapshot
 metadata:
   name: snapshot-manual
 spec:
-  snapshotContentName: snapshotcontent-manual
-  snapshotClassName: do-block-storage
+  source:
+        volumeSnapshotContentName: snapshotcontent-manual
 ```
 
 Make sure the name references between the `VolumeSnapshot` and the previously created `VolumeSnapshotContent` line up correctly.


### PR DESCRIPTION
If you try and use the existing VolumeSnapshot example this error is returned:

```shell
Error from server (BadRequest): error when creating "snapshot.yaml": VolumeSnapshot in version "v1" cannot be handled as a VolumeSnapshot: strict decoding error: unknown field "spec.snapshotClassName", unknown field "spec.snapshotContentName"
``` 