### PR TITLE
Disable fail-fast for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: push-images
     strategy:
+      fail-fast: false
       matrix:
         kube-release: ['1.26', '1.25', '1.24', '1.23']
 


### PR DESCRIPTION
If one of the e2e tests fails, the other tests are also canceled. Disable this behavior to minmize the number of complete reruns we have to do.