### PR TITLE
CON-9337 csi snapshot resizing

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -195,7 +195,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if snapshot != nil && vol != nil && volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
-		log.Info(fmt.Sprintf("volume %s will be resize from %d to %d", vol.ID, int(snapshot.SizeGigaBytes), int(volumeReq.SizeGigaBytes)))
+		log.Infof("volume %s will be resize from %d to %d", vol.ID, int(snapshot.SizeGigaBytes), int(volumeReq.SizeGigaBytes))
 		_, _, err = d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -188,7 +188,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	vol, cvResp, err := d.storage.CreateVolume(ctx, volumeReq)
 	if err != nil {
 		if cvResp != nil && cvResp.StatusCode == http.StatusForbidden && strings.Contains(err.Error(), "capacity limit exceeded") {
-			return nil, status.Errorf(codes.ResourceExhausted, "volume limit ha s been reached. Please contact support")
+			return nil, status.Errorf(codes.ResourceExhausted, "volume limit has been reached. Please contact support")
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -194,9 +194,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if volumeReq.SnapshotID != "" && snapshot != nil && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
-		log.Info("---- hit inside the volume snapshot ")
-		_, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
+	if snapshot != nil && vol != nil && volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
+		log.Info(fmt.Sprintf("volume %s will be resize from %d to %d", vol.ID, int(snapshot.SizeGigaBytes), int(volumeReq.SizeGigaBytes)))
+		_, _, err = d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -179,7 +179,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, err
 		}
 
-		log.WithField("response", resp).Info("snapshot was fetched")
+		log.WithField("snapshot_size_giga_bytes", snapshot.SizeGigaBytes).Info("snapshot size giga bytes")
 		log.WithField("snapshot_id", snapshotID).Info("using snapshot as volume source")
 		volumeReq.SnapshotID = snapshotID
 	}
@@ -196,11 +196,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	if snapshot != nil && vol != nil && volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
 		log.Infof("volume %s will be resize from %d to %d", vol.ID, int(snapshot.SizeGigaBytes), int(volumeReq.SizeGigaBytes))
-		_, _, err = d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
+		_, resp, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())
 		}
-		log.Info("volume was resized")
+		log.WithField("response", resp).Info("volume was resized")
 	}
 
 	resp := &csi.CreateVolumeResponse{

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -208,7 +208,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
 			if err := d.waitAction(ctx, log, vol.ID, action.ID); err != nil {
-				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, req.VolumeId, err)
+				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, vol.ID, err)
 			}
 		}
 	}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -196,9 +196,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	log.Info("---- just before the volumeReq.SnapshotID != \"\"")
 	log.WithField("volume_req_size_giga_bytes", volumeReq.SizeGigaBytes).Info("volume_req_size_giga_bytes")
 	log.WithField("volume_req_size_giga_bytes_int", int(volumeReq.SizeGigaBytes)).Info("volume_req_size_giga_bytes_int")
-	log.WithField("snapshot_size_giga_bytes", snapshot.SizeGigaBytes).Info("snapshot_size_giga_bytes")
-	log.WithField("snapshot_size_giga_bytes_int", int(volumeReq.SizeGigaBytes)).Info("snapshot_size_giga_bytes_int")
-	if volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
+	if snapshot != nil {
+		log.WithField("snapshot_size_giga_bytes", snapshot.SizeGigaBytes).Info("snapshot_size_giga_bytes")
+		log.WithField("snapshot_size_giga_bytes_int", int(snapshot.SizeGigaBytes)).Info("snapshot_size_giga_bytes_int")
+	}
+	if volumeReq.SnapshotID != "" && snapshot != nil && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
 		log.Info("---- hit inside the volume snapshot ")
 		_, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -211,7 +211,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
 			if err := d.waitAction(ctx, log, vol.ID, action.ID); err != nil {
-				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, req.VolumeId, err)
+				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, vol.ID, err)
 			}
 		}
 		log.Info("resize completed")

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -191,7 +191,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	log.Info("---- just before the volumeReq.SnapshotID != \"\"")
 	if volumeReq.SnapshotID != "" {
+		log.Info("---- hit inside the volume snapshot ")
 		action, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -187,7 +187,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	vol, cvResp, err := d.storage.CreateVolume(ctx, volumeReq)
 	if err != nil {
 		if cvResp != nil && cvResp.StatusCode == http.StatusForbidden && strings.Contains(err.Error(), "capacity limit exceeded") {
-			return nil, status.Errorf(codes.ResourceExhausted, "volume limit has been reached. Please contact support")
+			return nil, status.Errorf(codes.ResourceExhausted, "volume limit ha s been reached. Please contact support")
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -210,9 +210,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if action != nil && action.Status != "done" {
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
-			waitActionCtx, waitActionCancel := context.WithDeadline(ctx, time.Now().Add(time.Second*15))
-			defer waitActionCancel()
-			if err := d.waitAction(waitActionCtx, log, vol.ID, action.ID); err != nil {
+			if err := d.waitAction(ctx, log, vol.ID, action.ID); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, vol.ID, err)
 			}
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -207,7 +207,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			"resized_from": int(snapshot.SizeGigaBytes),
 			"resized_to":   int(volumeReq.SizeGigaBytes),
 		})
-		if action != nil && action.Status != godo.ActionCompleted {
+		if action != nil && action.Status != "done" {
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
 			waitActionCtx, waitActionCancel := context.WithDeadline(ctx, time.Now().Add(time.Second*15))
@@ -1051,7 +1051,7 @@ func (d *Driver) waitAction(ctx context.Context, log *logrus.Entry, volumeID str
 		}
 		log = log.WithField("action_status", action.Status)
 
-		if action.Status == godo.ActionCompleted {
+		if action.Status == godo.ActionCompleted || action.Status == "done" {
 			log.Info("action completed")
 			return true, nil
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -196,8 +196,24 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	log.WithField("volume_response", cvResp)
 
 	if snapshot != nil && volumeReq.SizeGigaBytes > int64(snapshot.SizeGigaBytes) && volumeReq.SizeGigaBytes > 1 {
+		log.WithField("volume_id", vol.ID)
+		log.WithField("volume_name", vol.Name)
+		//for {
+		//	volumes, _, err = d.storage.ListVolumes(ctx, &godo.ListVolumeParams{
+		//		Region: d.region,
+		//		Name:   vol.Name,
+		//	})
+		//	if len(volumes) > 1 {
+		//		break
+		//	}
+		//	if err != nil {
+		//		return nil, status.Errorf(codes.ResourceExhausted, "volume limit has been reached. Please contact support")
+		//	}
+		//
+		//}
 		log.Info("resizing volume because its requested size is larger than the size of the backing snapshot")
 		action, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -67,6 +67,9 @@ const (
 	// maxVolumesPerDropletErrorMessage is the error message returned by the DO
 	// API when the per-droplet volume limit would be exceeded.
 	maxVolumesPerDropletErrorMessage = "cannot attach more than 7 volumes to a single Droplet"
+
+	// doneActionStatus is used to determine if a Digital Ocean resize action is completed.
+	doneActionStatus = "done"
 )
 
 var (
@@ -207,7 +210,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			"resized_from": int(snapshot.SizeGigaBytes),
 			"resized_to":   int(volumeReq.SizeGigaBytes),
 		})
-		if action != nil && action.Status != "done" {
+		if action != nil && action.Status != doneActionStatus {
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
 			if err := d.waitAction(ctx, log, vol.ID, action.ID); err != nil {
@@ -1049,7 +1052,7 @@ func (d *Driver) waitAction(ctx context.Context, log *logrus.Entry, volumeID str
 		}
 		log = log.WithField("action_status", action.Status)
 
-		if action.Status == godo.ActionCompleted || action.Status == "done" {
+		if action.Status == godo.ActionCompleted || action.Status == doneActionStatus {
 			log.Info("action completed")
 			return true, nil
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -179,6 +179,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, err
 		}
 
+		log.WithField("response", resp).Info("snapshot was fetched")
 		log.WithField("snapshot_id", snapshotID).Info("using snapshot as volume source")
 		volumeReq.SnapshotID = snapshotID
 	}
@@ -193,13 +194,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	log.Info("---- just before the volumeReq.SnapshotID != \"\"")
-	log.WithField("volume_req_size_giga_bytes", volumeReq.SizeGigaBytes).Info("volume_req_size_giga_bytes")
-	log.WithField("volume_req_size_giga_bytes_int", int(volumeReq.SizeGigaBytes)).Info("volume_req_size_giga_bytes_int")
-	if snapshot != nil {
-		log.WithField("snapshot_size_giga_bytes", snapshot.SizeGigaBytes).Info("snapshot_size_giga_bytes")
-		log.WithField("snapshot_size_giga_bytes_int", int(snapshot.SizeGigaBytes)).Info("snapshot_size_giga_bytes_int")
-	}
 	if volumeReq.SnapshotID != "" && snapshot != nil && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
 		log.Info("---- hit inside the volume snapshot ")
 		_, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -210,7 +210,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if action != nil {
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
-			waitActionCtx, waitActionCancel := context.WithTimeout(ctx, time.Now().Add(time.Second*15))
+			waitActionCtx, waitActionCancel := context.WithDeadline(ctx, time.Now().Add(time.Second*15))
 			defer waitActionCancel()
 			if err := d.waitAction(waitActionCtx, log, vol.ID, action.ID); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, vol.ID, err)

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -210,7 +210,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if action != nil {
 			log = logWithAction(log, action)
 			log.Info("waiting until volume is resized")
-			if err := d.waitAction(ctx, log, vol.ID, action.ID); err != nil {
+			waitActionCtx, waitActionCancel := context.WithTimeout(ctx, time.Now().Add(time.Second*15))
+			defer waitActionCancel()
+			if err := d.waitAction(waitActionCtx, log, vol.ID, action.ID); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed waiting on action ID %d for volume ID %s to get resized: %s", action.ID, vol.ID, err)
 			}
 		}

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -194,13 +194,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if snapshot != nil && vol != nil && volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) {
+	if snapshot != nil && vol != nil && volumeReq.SnapshotID != "" && int(volumeReq.SizeGigaBytes) > int(snapshot.SizeGigaBytes) && int(volumeReq.SizeGigaBytes) > 1 {
 		log.Infof("volume %s will be resize from %d to %d", vol.ID, int(snapshot.SizeGigaBytes), int(volumeReq.SizeGigaBytes))
 		_, resp, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
+		log.WithField("response", resp).Info("volume was resized")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())
 		}
-		log.WithField("response", resp).Info("volume was resized")
 	}
 
 	resp := &csi.CreateVolumeResponse{

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -198,8 +198,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if snapshot != nil && volumeReq.SizeGigaBytes > int64(snapshot.SizeGigaBytes) && volumeReq.SizeGigaBytes > 1 {
-		_, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		log.Info("resizing volume because its requested size is larger than the size of the backing snapshot")
+		_, _, err := d.storageActions.Resize(ctx, vol.ID, int(volumeReq.SizeGigaBytes), volumeReq.Region)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", vol.ID, err.Error())
 		}

--- a/driver/node.go
+++ b/driver/node.go
@@ -27,6 +27,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"path/filepath"
 	"strings"
 
@@ -36,6 +37,7 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
+	mountutil "k8s.io/mount-utils"
 )
 
 const (
@@ -165,6 +167,25 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	} else {
 		log.Info("source device is already mounted to the target path")
 	}
+
+	log.Info("---- test hit ----")
+	r := mountutil.NewResizeFs(utilexec.New())
+	needResize, err := r.NeedResize(source, target)
+
+	if err != nil {
+		log.Info("---- test hit inside err need resize ----")
+		return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+	}
+
+	if needResize {
+		log.Info("---- test hit inside need resize ----")
+		klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
+		if _, err := r.Resize(source, target); err != nil {
+			log.Info("---- test hit inside need error resizing volume ----")
+			return nil, status.Errorf(codes.Internal, "Could not resize volume %q:  %v", req.VolumeId, err)
+		}
+	}
+
 
 	log.Info("formatting and mounting stage volume is finished")
 	return &csi.NodeStageVolumeResponse{}, nil

--- a/driver/node.go
+++ b/driver/node.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
-	//mountutil "k8s.io/mount-utils"
+	mountutil "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -167,9 +167,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		log.Info("source device is already mounted to the target path")
 	}
 
-	//log.Info("---- test hit ----")
-	//r := mountutil.NewResizeFs(utilexec.New())
-	//_, err = r.NeedResize(source, target)
+	log.Info("---- test hit ----")
+	r := mountutil.NewResizeFs(utilexec.New())
+	_, err = r.NeedResize(source, target)
 
 	//if err != nil {
 	//	log.Info("---- test hit inside err need resize ----")

--- a/driver/node.go
+++ b/driver/node.go
@@ -171,10 +171,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	r := mountutil.NewResizeFs(utilexec.New())
 	_, err = r.NeedResize(source, target)
 
-	//if err != nil {
-	//	log.Info("---- test hit inside err need resize ----")
-	//	return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
-	//}
+	if err != nil {
+		log.Info("---- test hit inside err need resize ----")
+		return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+	}
 	//
 	//if needResize {
 	//	log.Info("---- test hit inside need resize ----")

--- a/driver/node.go
+++ b/driver/node.go
@@ -27,8 +27,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +35,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
-	mountutil "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -168,30 +165,6 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	} else {
 		log.Info("source device is already mounted to the target path")
 	}
-
-	log.Info("---- test hit ----")
-	if _, err := os.Stat(source); err == nil {
-		log.Info("---- test hit inside file exist if ----")
-		r := mountutil.NewResizeFs(utilexec.New())
-		needResize, err := r.NeedResize(source, target)
-
-		if err != nil {
-			log.Info("---- test hit inside err need resize ----")
-			return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
-		}
-
-		log.Info(fmt.Sprintf("---- test no error need resize %t ----", needResize))
-		if needResize {
-			log.Info("---- test hit inside need resize ----")
-			klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
-			if _, err := r.Resize(source, target); err != nil {
-				log.Info("---- test hit inside need error resizing volume ----")
-				return nil, status.Errorf(codes.Internal, "Could not resize volume %q:  %v", req.VolumeId, err)
-			}
-		}
-	}
-
-
 
 	log.Info("formatting and mounting stage volume is finished")
 	return &csi.NodeStageVolumeResponse{}, nil

--- a/driver/node.go
+++ b/driver/node.go
@@ -180,7 +180,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
 		}
 
-		log.Info(fmt.Sprintf("---- test no error need resize %b ----", needResize))
+		log.Info(fmt.Sprintf("---- test no error need resize %t ----", needResize))
 		if needResize {
 			log.Info("---- test hit inside need resize ----")
 			klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)

--- a/driver/node.go
+++ b/driver/node.go
@@ -27,7 +27,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"path/filepath"
 	"strings"
 
@@ -36,8 +35,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
+	//mountutil "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
-	mountutil "k8s.io/mount-utils"
 )
 
 const (
@@ -168,24 +167,23 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		log.Info("source device is already mounted to the target path")
 	}
 
-	log.Info("---- test hit ----")
-	r := mountutil.NewResizeFs(utilexec.New())
-	needResize, err := r.NeedResize(source, target)
+	//log.Info("---- test hit ----")
+	//r := mountutil.NewResizeFs(utilexec.New())
+	//_, err = r.NeedResize(source, target)
 
-	if err != nil {
-		log.Info("---- test hit inside err need resize ----")
-		return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
-	}
-
-	if needResize {
-		log.Info("---- test hit inside need resize ----")
-		klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
-		if _, err := r.Resize(source, target); err != nil {
-			log.Info("---- test hit inside need error resizing volume ----")
-			return nil, status.Errorf(codes.Internal, "Could not resize volume %q:  %v", req.VolumeId, err)
-		}
-	}
-
+	//if err != nil {
+	//	log.Info("---- test hit inside err need resize ----")
+	//	return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+	//}
+	//
+	//if needResize {
+	//	log.Info("---- test hit inside need resize ----")
+	//	klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
+	//	if _, err := r.Resize(source, target); err != nil {
+	//		log.Info("---- test hit inside need error resizing volume ----")
+	//		return nil, status.Errorf(codes.Internal, "Could not resize volume %q:  %v", req.VolumeId, err)
+	//	}
+	//}
 
 	log.Info("formatting and mounting stage volume is finished")
 	return &csi.NodeStageVolumeResponse{}, nil

--- a/driver/node.go
+++ b/driver/node.go
@@ -27,6 +27,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -171,13 +172,17 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	log.Info(fmt.Sprintf("source: %s", source))
 	log.Info(fmt.Sprintf("target: %s", target))
 
-	r := mountutil.NewResizeFs(utilexec.New())
-	_, err = r.NeedResize(source, target)
+	if _, err := os.Stat(source); err == nil {
+		fmt.Printf("File exists\n");
+		r := mountutil.NewResizeFs(utilexec.New())
+		_, err = r.NeedResize(source, target)
 
-	if err != nil {
-		log.Info("---- test hit inside err need resize ----")
-		return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+		if err != nil {
+			log.Info("---- test hit inside err need resize ----")
+			return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+		}
 	}
+
 	//
 	//if needResize {
 	//	log.Info("---- test hit inside need resize ----")

--- a/driver/node.go
+++ b/driver/node.go
@@ -168,6 +168,9 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	log.Info("---- test hit ----")
+	log.Info(fmt.Sprintf("source: %s", source))
+	log.Info(fmt.Sprintf("target: %s", target))
+
 	r := mountutil.NewResizeFs(utilexec.New())
 	_, err = r.NeedResize(source, target)
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -27,6 +27,8 @@ package driver
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -35,6 +37,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
+	mountutil "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -164,6 +167,22 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 	} else {
 		log.Info("source device is already mounted to the target path")
+	}
+
+	if _, err := os.Stat(source); err == nil {
+		r := mountutil.NewResizeFs(utilexec.New())
+		needResize, err := r.NeedResize(source, target)
+
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", req.VolumeId, err)
+		}
+
+		if needResize {
+			klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", req.VolumeId)
+			if _, err := r.Resize(source, target); err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not resize volume %q:  %v", req.VolumeId, err)
+			}
+		}
 	}
 
 	log.Info("formatting and mounting stage volume is finished")

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	google.golang.org/grpc v1.51.0
 	gotest.tools/v3 v3.4.0
 	k8s.io/apimachinery v0.27.1
+	k8s.io/klog/v2 v2.90.1
 	k8s.io/mount-utils v0.27.1
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 )
@@ -53,7 +54,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.90.1 // indirect
 )
 
 replace k8s.io/api => k8s.io/api v0.27.1

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	google.golang.org/grpc v1.51.0
 	gotest.tools/v3 v3.4.0
 	k8s.io/apimachinery v0.27.1
-	k8s.io/klog/v2 v2.90.1
 	k8s.io/mount-utils v0.27.1
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 )
@@ -54,6 +53,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.90.1 // indirect
 )
 
 replace k8s.io/api => k8s.io/api v0.27.1

--- a/test/e2e/testdrivers/1.27.yaml
+++ b/test/e2e/testdrivers/1.27.yaml
@@ -27,7 +27,7 @@ DriverInfo:
     fsGroup: true
     volumeMountGroup: false
     exec: true
-    snapshotDataSource: false
+    snapshotDataSource: true
     pvcDataSource: false
     multipods: true
     RWX: false


### PR DESCRIPTION
Making sure that the upstream snapshot tests located [here](https://github.com/kubernetes/kubernetes/blob/v1.27.1/test/e2e/storage/testsuites/provisioning.go#L409) is green. 

Adding the functionality of creating a new PVC with a greater capacity from a volume snapshot. 