### PR TITLE
Make volumes-per-node limit configurable [CON-10973]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* Make volumes-per-node limit configurable
+  [[GH-575]](https://github.com/digitalocean/csi-digitalocean/pull/575)
+
 ## v4.10.0 - 2024.06.05
 
 * Handle new max-volumes-per-node error message

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -40,6 +40,7 @@ func main() {
 		defaultVolumesPageSize = flag.Uint("default-volumes-page-size", 0, "The default page size used when paging through volumes results (default: do not specify and let the DO API choose)")
 		doAPIRateLimitQPS      = flag.Float64("do-api-rate-limit", 0, "Impose QPS rate limit on DigitalOcean API usage (default: do not rate limit)")
 		validateAttachment     = flag.Bool("validate-attachment", false, "Validate if the attachment has fully completed before formatting/mounting the device")
+		volumeLimit            = flag.Uint("volume-limit", 7, "Volumes per node limit to report; needs to match limit imposed by DO storage backend (honored by Node service only)")
 		version                = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()
@@ -64,6 +65,7 @@ func main() {
 		DefaultVolumesPageSize: *defaultVolumesPageSize,
 		DOAPIRateLimitQPS:      *doAPIRateLimitQPS,
 		ValidateAttachment:     *validateAttachment,
+		VolumeLimit:            *volumeLimit,
 	})
 	if err != nil {
 		log.Fatalln(err)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -311,7 +311,7 @@ func (f *fakeStorageActionsDriver) Attach(ctx context.Context, volumeID string, 
 		return nil, resp, errors.New("droplet was not found")
 	}
 
-	if len(droplet.VolumeIDs) >= maxVolumesPerNode {
+	if len(droplet.VolumeIDs) >= defaultMaxVolumesPerNode {
 		resp.Response = &http.Response{
 			StatusCode: http.StatusUnprocessableEntity,
 		}

--- a/driver/node.go
+++ b/driver/node.go
@@ -45,9 +45,6 @@ const (
 	diskIDPath   = "/dev/disk/by-id"
 	diskDOPrefix = "scsi-0DO_Volume_"
 
-	// See: https://www.digitalocean.com/docs/volumes/overview/#limits
-	maxVolumesPerNode = 7
-
 	volumeModeBlock      = "block"
 	volumeModeFilesystem = "filesystem"
 )
@@ -343,7 +340,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	d.log.WithField("method", "node_get_info").Info("node get info called")
 	return &csi.NodeGetInfoResponse{
 		NodeId:            d.hostID(),
-		MaxVolumesPerNode: maxVolumesPerNode,
+		MaxVolumesPerNode: int64(d.volumeLimit),
 
 		// make sure that the driver works on this particular region only
 		AccessibleTopology: &csi.Topology{


### PR DESCRIPTION
This is to support a future DO block storage volume limit increase.

Adjusting the limit in the driver is to allow the Kubernetes scheduler to work correctly mostly. Specifically, it won't have an influence on what the DO storage backend permits. The two need to be synchronized.