### PR TITLE
update action-gh-release in order to fix release failure fetching tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           DOCKER_REPO=${DOCKER_ORG}/do-csi-plugin make publish
 
       - name: create Github release
-        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf  # v0.1.5
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Release [started failing](https://github.com/digitalocean/csi-digitalocean/actions/runs/10318162175/job/28817212517) with this weird error:
```
Unexpected error fetching GitHub release for tag refs/tags/v4.11.0: HttpError: Not Found
```
even though the tag exists.

With updated action it appears to work: https://github.com/digitalocean/csi-digitalocean/actions/runs/10406682838/job/28820281895 (this is just a release draft I did for testing)