### PR TITLE
Fix mounting of XFS volumes restored from snapshots

### DIFF
--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -207,6 +207,12 @@ func (m *mounter) Mount(source, target, fsType string, opts ...string) error {
 		}
 	}
 
+	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+	if fsType == "xfs" {
+		opts = append(opts, "nouuid")
+	}
+
 	if len(opts) > 0 {
 		mountArgs = append(mountArgs, "-o", strings.Join(opts, ","))
 	}

--- a/test/e2e/run-versioned-e2e-tests.sh
+++ b/test/e2e/run-versioned-e2e-tests.sh
@@ -68,5 +68,5 @@ if [[ "${SKIP_SEQUENTIAL_TESTS:-}" ]]; then
   echo 'Skipping sequential tests'
 else
   echo 'Running sequential tests'
-  "ginkgo-${KUBE_VER}" -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]|\[Feature:VolumeSourceXFS\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
+  "ginkgo-${KUBE_VER}" -v -focus="External.Storage${focus}.*(\[Feature:|\[Serial\])" -skip='\[Disruptive\]' "${E2E_TEST_FILE}" -- "-storage.testdriver=${TD_FILE}"
 fi


### PR DESCRIPTION
Applying essentially the same workaround as other providers, e.g. https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/788