### PR TITLE
Fixed the max volume mount default from 7 to 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Adjusted max volume mounts from 7 to 15
+
 ## v4.17.0 - 2026.05.06
 
 * Update Go to 1.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Adjusted max volume mounts from 7 to 15
+* Adjusted default max volume limit per node from 7 to 15.
 
 ## v4.17.0 - 2026.05.06
 

--- a/cmd/do-csi-plugin/main.go
+++ b/cmd/do-csi-plugin/main.go
@@ -40,7 +40,7 @@ func main() {
 		defaultVolumesPageSize = flag.Uint("default-volumes-page-size", 0, "The default page size used when paging through volumes results (default: do not specify and let the DO API choose)")
 		doAPIRateLimitQPS      = flag.Float64("do-api-rate-limit", 0, "Impose QPS rate limit on DigitalOcean API usage (default: do not rate limit)")
 		validateAttachment     = flag.Bool("validate-attachment", false, "Validate if the attachment has fully completed before formatting/mounting the device")
-		volumeLimit            = flag.Uint("volume-limit", 7, "Volumes per node limit to report; needs to match limit imposed by DO storage backend (honored by Node service only)")
+		volumeLimit            = flag.Uint("volume-limit", driver.DefaultMaxVolumesPerNode, "Volumes per node limit to report; needs to match limit imposed by DO storage backend (honored by Node service only)")
 		version                = flag.Bool("version", false, "Print the version and exit.")
 	)
 	flag.Parse()

--- a/driver/controller_test.go
+++ b/driver/controller_test.go
@@ -270,7 +270,7 @@ func TestControllerExpandVolume(t *testing.T) {
 						"volume-id": tc.volume,
 					},
 				},
-				log: logrus.New().WithField("test_enabed", true),
+				log: logrus.New().WithField("test_enabled", true),
 			}
 			resp, err := driver.ControllerExpandVolume(context.Background(), tc.req)
 			if err != nil {
@@ -529,13 +529,13 @@ func TestWaitAction(t *testing.T) {
 					fakeStorageActionsDriver: &fakeStorageActionsDriver{},
 					storageGetValsFunc:       test.storageGetValsFunc,
 				},
-				log: logrus.New().WithField("test_enabed", true),
+				log: logrus.New().WithField("test_enabled", true),
 			}
 
 			ctx, _ := context.WithTimeout(context.Background(), test.timeout)
 			err := d.waitAction(
 				ctx,
-				logrus.New().WithField("test_enabed", true),
+				logrus.New().WithField("test_enabled", true),
 				"volumeID",
 				42,
 			)
@@ -650,7 +650,7 @@ func TestListSnapshot(t *testing.T) {
 				snapshots: &fakeSnapshotsDriver{
 					snapshots: snapshots,
 				},
-				log: logrus.New().WithField("test_enabed", true),
+				log: logrus.New().WithField("test_enabled", true),
 			}
 
 			resp, err := d.ListSnapshots(context.Background(), &csi.ListSnapshotsRequest{

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -43,7 +43,9 @@ const (
 	// system for the canonical, official name of this plugin
 	DefaultDriverName = "dobs.csi.digitalocean.com"
 
-	defaultMaxVolumesPerNode = 7
+	// DefaultMaxVolumesPerNode defines the default maximum number of volumes
+	// that can be attached to a single node.
+	DefaultMaxVolumesPerNode = 15
 )
 
 var (

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -94,10 +94,11 @@ func TestDriverSuite(t *testing.T) {
 			dropletIdx++
 			return strconv.Itoa(droplets[i+1].ID)
 		},
-		doTag:   doTag,
-		region:  "nyc3",
-		mounter: fm,
-		log:     logrus.New().WithField("test_enabed", true),
+		doTag:       doTag,
+		region:      "nyc3",
+		mounter:     fm,
+		log:         logrus.New().WithField("test_enabled", true),
+		volumeLimit: DefaultMaxVolumesPerNode,
 
 		storage: &fakeStorageDriver{
 			volumes:   volumes,
@@ -311,7 +312,7 @@ func (f *fakeStorageActionsDriver) Attach(ctx context.Context, volumeID string, 
 		return nil, resp, errors.New("droplet was not found")
 	}
 
-	if len(droplet.VolumeIDs) >= defaultMaxVolumesPerNode {
+	if len(droplet.VolumeIDs) >= DefaultMaxVolumesPerNode {
 		resp.Response = &http.Response{
 			StatusCode: http.StatusUnprocessableEntity,
 		}


### PR DESCRIPTION
I ran into an issue with the maximum volume mounts hitting the limit of 7. According to https://docs.digitalocean.com/products/volumes/details/limits/ the limit is raised to 15 now.  

There was a const that defined the value, as well as a command line flag, i consolidated it down to a single source of truth in the const, and also updated the case to match other const patterns.

I also fixed a typo in some tests that said test_enabed, changed to test_enabled.